### PR TITLE
Fix exception when keyboard navigating an empty TreeDataGrid.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -84,6 +84,9 @@ namespace Avalonia.Controls.Primitives
 
         public void BringIntoView(int index)
         {
+            if (_items is null || index < 0 || index >= _items.Count)
+                return;
+
             if (GetRealizedElement(index) is IControl element)
             {
                 element.BringIntoView();

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -221,7 +221,7 @@ namespace Avalonia.Controls
 
         private bool MoveSelection(NavigationDirection direction, bool rangeModifier, ITreeDataGridCell? focused)
         {
-            if (Source is null || RowsPresenter is null)
+            if (Source is null || RowsPresenter is null || Source.Columns.Count == 0 || Source.Rows.Count == 0)
                 return false;
 
             var currentColumnIndex = focused?.ColumnIndex ?? 0;


### PR DESCRIPTION
- Don't attempt keyboard navigation when the source is empty
- Put a bounds check in `TreeDataGridPresenterBase.BeingIntoView` anyway

Fixes #2