### PR TITLE
Set IsSelected only if selection model exists

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -71,7 +71,11 @@ namespace Avalonia.Controls.Primitives
         {
             var row = (TreeDataGridRow)element;
             row.Realize(ElementFactory, Columns, (IRows?)Items, index);
-            row.IsSelected = _selection?.IsSelected(index) == true;
+
+            if (_selection is { } selection)
+            {
+                row.IsSelected = selection.IsSelected(index);
+            }
         }
 
         protected override void UpdateElementIndex(IControl element, int index)


### PR DESCRIPTION
When a selection model isn't provided, but selection is done by custom code for extended scenarios and/or to tweak some pointer events, it's not possible to visualize selected items. If `IsSelected` is bound in a style, a bound value is overwritten by a directly set one. This pull request allows to bind `IsSelected` and use it as a source.