### PR TITLE
Fix running all tests at one time

### DIFF
--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using Xunit;
+
+// Don't run tests in parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Before that PR if you would run all tests at one time some of them would fail because of unnecessary tests parallelization. This PR fixes it