### PR TITLE
Get initial actual width from inner column.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalExpanderColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalExpanderColumn.cs
@@ -35,6 +35,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             _inner.PropertyChanged += OnInnerPropertyChanged;
             _childSelector = childSelector;
             _hasChildrenSelector = hasChildrenSelector;
+            _actualWidth = inner.ActualWidth;
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a crash when using `HierarchicalExpanderColumn` with a pixel width.