### PR TITLE
Fix the header bottom border

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml
@@ -16,15 +16,15 @@
                 BorderThickness="{TemplateBinding BorderThickness}">
           <DockPanel>
             <ScrollViewer DockPanel.Dock="Top"
-                          BorderThickness="0 0 0 1"
-                          BorderBrush="{DynamicResource TreeDataGridGridLinesBrush}"
                           IsVisible="{TemplateBinding ShowColumnHeaders}"
                           Offset="{Binding Scroll.Offset, RelativeSource={RelativeSource TemplatedParent}}"
                           HorizontalScrollBarVisibility="Hidden"
                           VerticalScrollBarVisibility="Disabled">
-              <TreeDataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
-                                                  ElementFactory="{TemplateBinding ElementFactory}"
-                                                  Items="{TemplateBinding Columns}"/>
+              <Border BorderThickness="0 0 0 1" BorderBrush="{DynamicResource TreeDataGridGridLinesBrush}">
+                <TreeDataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
+                                                    ElementFactory="{TemplateBinding ElementFactory}"
+                                                    Items="{TemplateBinding Columns}"/>
+              </Border>
             </ScrollViewer>
             <ScrollViewer Name="PART_ScrollViewer"
                           HorizontalScrollBarVisibility="Auto">


### PR DESCRIPTION
The [TreeDataGridRowsPresenter's Scrollviewer](https://github.com/AvaloniaUI/Avalonia.ProControls/blob/34015d059af08d38c3fb608594[…]79b5eada/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml) wasn't drawing the bottom border line.

This PR fixes the issue.