### PR TITLE
Fix TreeDataGridPresenter not cleaning child elements on recycling

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -391,7 +391,7 @@ namespace Avalonia.Controls.Primitives
         {
             UnrealizeElement(element);
             element.IsVisible = false;
-            _children.Remove(element);
+            
             _recycleArgs ??= new ElementFactoryRecycleArgs();
             _recycleArgs.Element = element;
             _recycleArgs.Parent = this;
@@ -501,18 +501,25 @@ namespace Avalonia.Controls.Primitives
             {
                 var first = _realizedElements.FirstIndex;
                 var last = _realizedElements.LastIndex;
-
-                if (index >= first && index <= last)
+                if (_realizedElements.FirstIndex == -1 && _realizedElements.LastIndex == -1 && _children.Count > 0)
                 {
-                    var removePoint = index - first;
+                    _children.RemoveRange(index, count);
+                }
+                else if ((index >= first && index <= last) || ((count - index) > first))
+                {
+                    var removePoint = index - first > 0 ? index - first : 0;
                     count = Math.Min(count, _realizedElements.Count - removePoint);
-
+                    if (count <= 0)
+                    {
+                        return;
+                    }
                     for (var i = 0; i < count; ++i)
                     {
                         if (_realizedElements.Elements[removePoint + i] is IControl element)
                             RecycleElement(element);
                     }
 
+                    _children.RemoveRange(removePoint, count);
                     _realizedElements.RemoveRange(removePoint, count);
 
                     for (var i = removePoint; i < _realizedElements.Count; ++i)


### PR DESCRIPTION
I made a repro of #13 in fix-cell-events branch. When we cleared elements in our `Source.Items` property they kept existing in the visual tree. I assume we have to fix that by manually managing child elements.
closes #13 
Open question-should we cover that behaviour with tests?