### PR TITLE
Setting DataContext for rows with models

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
@@ -72,7 +72,7 @@ namespace Avalonia.Controls
             return new AnonymousSortableRows<TModel>(_itemsView, _comparer);
         }
 
-        private ICell CreateCell(IRow<TModel> row, int columnIndex)
+        private ICell CreateCell(IModelRow<TModel> row, int columnIndex)
         {
             return Columns[columnIndex].CreateCell(row);
         }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/AnonymousRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/AnonymousRow.cs
@@ -12,10 +12,12 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// In a flat grid where rows cannot be resized, it is not necessary to persist any information
     /// about rows; the same row object can be updated and reused when a new row is requested.
     /// </remarks>
-    internal class AnonymousRow<TModel> : IRow<TModel>
+    internal class AnonymousRow<TModel> : IModelRow<TModel>
     {
         private int _index;
         [AllowNull] private TModel _model;
+
+        object IModelRow.Model => Model;
 
         public object? Header => _index;
         public TModel Model => _model;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/AnonymousSortableRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/AnonymousSortableRows.cs
@@ -16,7 +16,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// In a flat grid where rows cannot be resized, it is not necessary to persist any information
     /// about rows; the same row object can be updated and reused when a new row is requested.
     /// </remarks>
-    public class AnonymousSortableRows<TModel> : ReadOnlyListBase<IRow<TModel>>, IRows, IDisposable
+    public class AnonymousSortableRows<TModel> : ReadOnlyListBase<IModelRow<TModel>>, IRows, IDisposable
     {
         private readonly AnonymousRow<TModel> _row;
         private ItemsSourceViewFix<TModel> _items;
@@ -33,7 +33,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             _row = new AnonymousRow<TModel>();
         }
 
-        public override IRow<TModel> this[int index]
+        public override IModelRow<TModel> this[int index]
         {
             get
             {
@@ -61,7 +61,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             return (-1, -1);
         }
 
-        public override IEnumerator<IRow<TModel>> GetEnumerator()
+        public override IEnumerator<IModelRow<TModel>> GetEnumerator()
         {
             for (var i = 0; i < Count; ++i)
                 yield return this[i];

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CollectionExtensions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             Comparison<TModel> comparison,
             int from = 0,
             int to = -1)
-                where TRow : IRow<TModel>
+                where TRow : IModelRow<TModel>
         {
             to = to == -1 ? items.Count - 1 : to;
 

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
@@ -91,7 +91,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// </summary>
         /// <param name="row">The row.</param>
         /// <returns>The cell.</returns>
-        public abstract ICell CreateCell(IRow<TModel> row);
+        public abstract ICell CreateCell(IModelRow<TModel> row);
 
         public abstract Comparison<TModel>? GetComparison(ListSortDirection direction);
 

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalExpanderColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalExpanderColumn.cs
@@ -58,7 +58,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
         public GridLength Width => _inner.Width;
 
-        public ICell CreateCell(IRow<TModel> row)
+        public ICell CreateCell(IModelRow<TModel> row)
         {
             if (row is HierarchicalRow<TModel> r)
             {

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
@@ -58,6 +58,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// </summary>
         public IndexPath ModelIndexPath { get; private set; }
 
+        object IModelRow.Model => Model;
+
         public object? Header => ModelIndexPath;
         public int Indent => ModelIndexPath.GetSize() - 1;
         public TModel Model { get; }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IColumn`1.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IColumn`1.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// </summary>
         /// <param name="row">The row.</param>
         /// <returns>The cell.</returns>
-        ICell CreateCell(IRow<TModel> row);
+        ICell CreateCell(IModelRow<TModel> row);
 
         /// <summary>
         /// Gets a comparison function for the column.

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IExpanderRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IExpanderRow.cs
@@ -6,7 +6,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// Represents a row which can be expanded to reveal nested data.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public interface IExpanderRow<TModel> : IRow<TModel>, IExpander, INotifyPropertyChanged
+    public interface IExpanderRow<TModel> : IModelRow<TModel>, IExpander, INotifyPropertyChanged
     {
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IModelRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IModelRow.cs
@@ -1,15 +1,15 @@
-﻿namespace Avalonia.Controls.Models.TreeDataGrid
+namespace Avalonia.Controls.Models.TreeDataGrid
 {
     /// <summary>
-    /// Base class for rows with a model taken from an indexable data source.
+    /// Base interface for rows with a model taken from an indexable data source.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public interface IRow<TModel> : IRow
+    public interface IModelRow : IRow
     {
         /// <summary>
         /// Gets the row model.
         /// </summary>
-        TModel Model { get; }
+        object Model { get; }
 
         /// <summary>
         /// Gets the index of the model in the data source.

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IModelRow`1.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IModelRow`1.cs
@@ -1,0 +1,14 @@
+﻿namespace Avalonia.Controls.Models.TreeDataGrid
+{
+    /// <summary>
+    /// Base interface for rows with a strongly typed model taken from an indexable data source.
+    /// </summary>
+    /// <typeparam name="TModel">The model type.</typeparam>
+    public interface IModelRow<TModel> : IModelRow
+    {
+        /// <summary>
+        /// Gets the row model.
+        /// </summary>
+        new TModel Model { get; }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/SortableRowsBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/SortableRowsBase.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// <typeparam name="TModel">The model type.</typeparam>
     /// <typeparam name="TRow">The row type.</typeparam>
     public abstract class SortableRowsBase<TModel, TRow> : ReadOnlyListBase<TRow>, IDisposable
-        where TRow : IRow<TModel>, IDisposable
+        where TRow : IModelRow<TModel>, IDisposable
     {
         private ItemsSourceViewFix<TModel> _items;
         private Comparison<TModel>? _comparison;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumn.cs
@@ -37,7 +37,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// </summary>
         /// <param name="row">The row.</param>
         /// <returns>The cell.</returns>
-        public override ICell CreateCell(IRow<TModel> row) => new TemplateCell(row.Model, CellTemplate);
+        public override ICell CreateCell(IModelRow<TModel> row) => new TemplateCell(row.Model, CellTemplate);
 
         public override Comparison<TModel>? GetComparison(ListSortDirection direction)
         {

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
@@ -56,7 +56,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         {
         }
 
-        public override ICell CreateCell(IRow<TModel> row)
+        public override ICell CreateCell(IModelRow<TModel> row)
         {
             return new TextCell<TValue>(CreateBindingExpression(row.Model), Binding.Write is null);
         }

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -82,6 +82,12 @@ namespace Avalonia.Controls.Primitives
         {
             RowIndex = index;
             CellsPresenter?.UpdateIndex(index);
+
+            if (Rows is IRows rows &&
+                rows[index] is IModelRow row)
+            {
+                DataContext = row.Model;
+            }
         }
 
         public void Unrealize()

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -175,7 +175,7 @@ namespace Avalonia.Controls
             if (Source is object &&
                 TryGetRow(element, out var row) &&
                 row.RowIndex < Source.Rows.Count &&
-                Source.Rows[row.RowIndex] is IRow<TModel> rowWithModel)
+                Source.Rows[row.RowIndex] is IModelRow<TModel> rowWithModel)
             {
                 result = rowWithModel.Model;
                 return true;

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/FlatTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/FlatTreeDataGridSourceTests.cs
@@ -380,7 +380,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
             for (var i = 0; i < data.Count; ++i)
             {
-                var row = (IRow<Row>)rows[i];
+                var row = (IModelRow<Row>)rows[i];
                 Assert.Same(row.Model, data[i]);
                 Assert.Equal(i, row.ModelIndex);
             }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridCellsPresenterTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridCellsPresenterTests.cs
@@ -182,7 +182,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             {
             }
 
-            public override ICell CreateCell(IRow<Model> row)
+            public override ICell CreateCell(IModelRow<Model> row)
             {
                 return new TextCell<string>($"{Header} Row {row.ModelIndex}");
             }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridColumnHeadersPresenterTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridColumnHeadersPresenterTests.cs
@@ -197,7 +197,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             {
             }
 
-            public override ICell CreateCell(IRow<string> row)
+            public override ICell CreateCell(IModelRow<string> row)
             {
                 throw new NotImplementedException();
             }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridRowsPresenterTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridRowsPresenterTests.cs
@@ -23,6 +23,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
 
             Assert.Equal(new Size(100, 1000), scroll.Extent);
             AssertRowIndexes(target, 0, 10);
+            AssertRowContexts(target, 0, 10);
             AssertRecyclable(target, 0);
         }
 
@@ -37,6 +38,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             Layout(target);
 
             AssertRowIndexes(target, 1, 10);
+            AssertRowContexts(target, 1, 10);
             AssertRecyclable(target, 0);
         }
 
@@ -51,6 +53,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             Layout(target);
 
             AssertRowIndexes(target, 20, 10);
+            AssertRowContexts(target, 20, 10);
             AssertRecyclable(target, 0);
         }
 
@@ -68,6 +71,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             Layout(target);
 
             AssertRowIndexes(target, 0, 10);
+            AssertRowContexts(target, 0, 10);
             AssertRecyclable(target, 0);
         }
 
@@ -274,6 +278,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             target.BringIntoView(10);
 
             AssertRowIndexes(target, 1, 10);
+            AssertRowContexts(target, 1, 10);
         }
 
         private static void AssertRowIndexes(TreeDataGridRowsPresenter? target, int firstRowIndex, int rowCount)
@@ -301,6 +306,37 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             Assert.Equal(
                 Enumerable.Range(firstRowIndex, rowCount),
                 rowIndexes);
+        }
+
+        private static void AssertRowContexts(TreeDataGridRowsPresenter? target, int firstRowIndex, int rowCount)
+        {
+            Assert.NotNull(target);
+            Assert.NotNull(target!.Items);
+
+            var expected = target!.Items!
+                .Skip(firstRowIndex)
+                .Take(rowCount)
+                .Cast<IModelRow>()
+                .Select(x => x.Model)
+                .ToArray();
+
+            var actualLogical = target!.GetLogicalChildren()
+                .Cast<TreeDataGridRow>()
+                .Where(x => x.IsVisible)
+                .OrderBy(x => x.RowIndex)
+                .Select(x => x.DataContext)
+                .ToArray();
+
+            Assert.Equal(expected, actualLogical);
+
+            var actualRealized = target!.RealizedElements
+                .Cast<TreeDataGridRow>()
+                .Where(x => x.IsVisible)
+                .OrderBy(x => x.RowIndex)
+                .Select(x => x.DataContext)
+                .ToArray();
+
+            Assert.Equal(expected, actualRealized);
         }
 
         private static void AssertRecyclable(TreeDataGridRowsPresenter? target, int count)


### PR DESCRIPTION
`DataContext` is required in case of attached properties and behaviors, bindings in styles and event handling. The last one is possible without a context, but it makes things a bit more complicated. The first three won't work even with binding `DataContext` manually since `RowIndex` isn't a dependency property, so updating indexes won't affect bindings.