### PR TITLE
Implemented a hacky way to maintain tree selection on sort.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
@@ -23,7 +23,9 @@ namespace Avalonia.Controls
             Columns = new ColumnList<TModel>();
         }
 
-        public event Action? Sorted;
+        public event Action? BeforeSort;
+        public event Action? AfterSort;
+
         public ColumnList<TModel> Columns { get; }
         public IRows Rows => _rows ??= CreateRows();
         IColumns ITreeDataGridSource.Columns => Columns;
@@ -56,10 +58,11 @@ namespace Avalonia.Controls
                 if (comparer is object)
                 {
                     _comparer = comparer is object ? new FuncComparer<TModel>(comparer) : null;
+                    BeforeSort?.Invoke();
                     _rows?.Sort(_comparer, selection);
-                    Sorted?.Invoke();
                     foreach (var c in Columns)
                         c.SortDirection = c == column ? direction : null;
+                    AfterSort?.Invoke();
                 }
                 return true;
             }

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -37,7 +37,10 @@ namespace Avalonia.Controls
             Columns = new ColumnList<TModel>();
             Columns.CollectionChanged += OnColumnsCollectionChanged;
         }
-        public event Action? Sorted;
+
+        public event Action? BeforeSort;
+        public event Action? AfterSort;
+
         public IEnumerable<TModel> Items 
         {
             get => _items;
@@ -77,8 +80,9 @@ namespace Avalonia.Controls
                 Columns.Contains(columnBase) &&
                 columnBase.GetComparison(direction) is Comparison<TModel> comparison)
             {
+                BeforeSort?.Invoke();
                 Sort(comparison);
-                Sorted?.Invoke();
+                AfterSort?.Invoke();
                 foreach (var c in Columns)
                     c.SortDirection = c == column ? (ListSortDirection?)direction : null;
                 return true;

--- a/src/Avalonia.Controls.TreeDataGrid/ITreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/ITreeDataGridSource.cs
@@ -10,11 +10,15 @@ namespace Avalonia.Controls
     /// </summary>
     public interface ITreeDataGridSource
     {
+        /// <summary>
+        /// Raised before the source begins a sort operation.
+        /// </summary>
+        event Action BeforeSort;
 
         /// <summary>
-        /// Event which would be triggered after SortBy method execution.
+        /// Raised after a sort operation on the the source ends.
         /// </summary>
-        event Action Sorted;
+        event Action AfterSort;
 
         /// <summary>
         /// Gets the columns to be displayed.

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -126,16 +126,13 @@ namespace Avalonia.Controls
                 {
                     if (value != null)
                     {
-                        value.Sorted += Source_Sorted;
+                        value.BeforeSort += BeforeSourceSort;
+                        value.AfterSort += AfterSourceSort;
                     }
                     if (_source!=null)
                     {
-                        _source.Sorted -= Source_Sorted;
-                    }
-                    void Source_Sorted()
-                    {
-                        RowsPresenter?.RecycleAllElements();
-                        RowsPresenter?.InvalidateMeasure();
+                        _source.BeforeSort -= BeforeSourceSort;
+                        _source.AfterSort -= AfterSourceSort;
                     }
 
                     var oldSource = _source;
@@ -150,6 +147,8 @@ namespace Avalonia.Controls
             }
         }
 
+        public event EventHandler BeforeSort;
+        public event EventHandler AfterSort;
         public event EventHandler<TreeDataGridCellEventArgs>? CellClearing;
         public event EventHandler<TreeDataGridCellEventArgs>? CellPrepared;
         public event CancelEventHandler SelectionChanging;
@@ -430,6 +429,18 @@ namespace Avalonia.Controls
                 CellPrepared(this, _cellArgs);
                 _cellArgs.Update(null, -1, -1);
             }
+        }
+
+        private void BeforeSourceSort()
+        {
+            BeforeSort?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void AfterSourceSort()
+        {
+            RowsPresenter?.RecycleAllElements();
+            RowsPresenter?.InvalidateMeasure();
+            AfterSort?.Invoke(this, EventArgs.Empty);
         }
 
         private void OnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Added `BeforeSort` and `AfterSort` events to `TreeDataGrid`. This can be used to save the current selection before sorting and restore it after sorting.

Added an example of this to the sample.

This is a hack because our tree selection code needs to be rewritten.