### PR TITLE
Added row realization check on selection update

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -93,7 +93,7 @@ namespace Avalonia.Controls.Primitives
         {
             foreach (var element in LogicalChildren)
             {
-                if (element is TreeDataGridRow row)
+                if (element is TreeDataGridRow { RowIndex: >= 0 } row)
                 {
                     row.IsSelected = _selection?.IsRowSelected(row.RowIndex) == true;
                 }


### PR DESCRIPTION
The change protects custom implementations of interaction interfaces to hit a situation, when they asked for selection status of an unrealized row. It's a bit unexpected that the index is out of range.