### PR TITLE
Handle collections being reset in TreeSelectionModel.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeSelectionModel.cs
@@ -18,6 +18,7 @@ namespace Avalonia.Controls.Selection
 
         event EventHandler<TreeSelectionModelSelectionChangedEventArgs>? SelectionChanged;
         event EventHandler<TreeSelectionModelIndexesChangedEventArgs>? IndexesChanged;
+        event EventHandler<TreeSelectionModelSourceResetEventArgs>? SourceReset;
 
         void BeginBatchUpdate();
         void Clear();

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelSourceResetEventArgs.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelSourceResetEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Avalonia.Controls.Selection
+{
+    public class TreeSelectionModelSourceResetEventArgs : EventArgs
+    {
+        public TreeSelectionModelSourceResetEventArgs(IndexPath parentIndex)
+        {
+            ParentIndex = parentIndex;
+        }
+
+        public IndexPath ParentIndex { get; }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionNode.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionNode.cs
@@ -144,6 +144,9 @@ namespace Avalonia.Controls.Selection
                     indexesChanged = shiftDelta != 0;
                     removed = removeChange.RemovedItems;
                     break;
+                case NotifyCollectionChangedAction.Reset:
+                    OnSourceReset();
+                    break;
                 default:
                     throw new NotSupportedException($"Collection {e.Action} not supported.");
             }
@@ -176,14 +179,10 @@ namespace Avalonia.Controls.Selection
                 _owner.OnNodeCollectionChanged(Path, shiftIndex, shiftDelta, indexesChanged, removed);
         }
 
-        protected override void OnSourceCollectionChangeFinished()
-        {
-            _owner.OnNodeCollectionChangeFinished();
-        }
-
         protected override void OnSourceReset()
         {
-            throw new NotImplementedException();
+            CommitDeselect(new IndexRange(0, int.MaxValue));
+            _owner.OnNodeCollectionReset(Path);
         }
 
         private TreeSelectionNode<T>? GetChild(int index, bool realize)


### PR DESCRIPTION
Raises the `SourceReset` event with the parent index when a collection reset occurs.