### PR TITLE
Fixed property change handling by base class

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -103,7 +103,7 @@ namespace Avalonia.Controls.Primitives
         {
             if (change.Property == IsSelectedProperty)
             {
-                PseudoClasses.Set(":selected", change.NewValue.GetValueOrDefault<bool>());
+                PseudoClasses.Set(":selected", IsSelected);
             }
             
             base.OnPropertyChanged(change);


### PR DESCRIPTION
Without handling property changes by the base class, pseudo classes present by `InputElement` are not set. For example, `focus-within` won't be set while `IsKeyboardFocusWithin` is `true`.