### PR TITLE
Assign TreeDataGridRow.DataContext to model being displayed.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IRow.cs
@@ -14,5 +14,10 @@
         /// Gets the height of the row.
         /// </summary>
         GridLength Height { get; set; }
+
+        /// <summary>
+        /// Gets the row model.
+        /// </summary>
+        object? Model { get; }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IRow`1.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IRow`1.cs
@@ -9,7 +9,12 @@
         /// <summary>
         /// Gets the row model.
         /// </summary>
-        TModel Model { get; }
+        new TModel Model { get; }
+
+        /// <summary>
+        /// Gets the untyped row model.
+        /// </summary>
+        object? IRow.Model => Model;
 
         /// <summary>
         /// Updates the model index due to a change in the data source.

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -70,6 +70,7 @@ namespace Avalonia.Controls.Primitives
             ElementFactory = elementFactory;
             Columns = columns;
             Rows = rows;
+            DataContext = rows?[rowIndex].Model;
             UpdateIndex(rowIndex);
         }
 
@@ -87,6 +88,7 @@ namespace Avalonia.Controls.Primitives
         public void Unrealize()
         {
             RowIndex = -1;
+            DataContext = null;
             CellsPresenter?.Unrealize();
         }
 

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridRowsPresenterTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridRowsPresenterTests.cs
@@ -435,6 +435,26 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             AssertRowIndexes(target, 0, 10);
         }
 
+        [Fact]
+        public void Assigns_Row_DataContexts()
+        {
+            using var app = App();
+
+            var (target, scroll, items) = CreateTarget();
+            var lastRow = (TreeDataGridRow)target.RealizedElements.Last()!;
+
+            for (var i = 0; i < 10; ++i)
+            {
+                Assert.Same(items[i], target.RealizedElements[i]!.DataContext);
+            }
+
+            items.RemoveRange(0, 99);
+            Layout(target);
+
+            Assert.Equal(-1, lastRow.RowIndex);
+            Assert.Null(lastRow.DataContext);
+        }
+
         private static void AssertRowIndexes(TreeDataGridRowsPresenter? target, int firstRowIndex, int rowCount)
         {
             Assert.NotNull(target);


### PR DESCRIPTION
To allow easier custom bindings.