### PR TITLE
Fix keyboard selection when current selection is scrolled offscreen.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeSelectionModel.cs
@@ -55,12 +55,25 @@ namespace Avalonia.Controls.Selection
         /// <remarks>
         /// The anchor index holds the index of the item from which non-ranged keyboard selection
         /// will start, i.e. in a vertical list it will hold the item from which selection should
-        /// be moved by pressing the up or down arrow key.
+        /// be moved by pressing the up or down arrow key. This is usually the last selected item.
         /// 
-        /// It is automatically set when selecting an index via
+        /// <see cref="AnchorIndex"/> is automatically set when selecting an item via
         /// <see cref="SelectedIndex"/> or <see cref="Select(IndexPath)"/>.
         /// </remarks>
         IndexPath AnchorIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets the range anchor index.
+        /// </summary>
+        /// <remarks>
+        /// The range anchor index holds the index of the item from which ranged selection will
+        /// start, i.e. when shift-clicking an item it represents the start of the range to be 
+        /// selected whereas the shift-clicked item will be the end of the range.
+        /// 
+        /// <see cref="RangeAnchorIndex"/> is set when selecting an item via
+        /// <see cref="SelectedIndex"/> but not via <see cref="Select(IndexPath)"/>.
+        /// </remarks>
+        IndexPath RangeAnchorIndex { get; set; }
 
         /// <summary>
         /// Gets the number of selected items.

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -162,7 +162,7 @@ namespace Avalonia.Controls.Selection
             {
                 if (!treeDataGrid.QueryCancelSelection())
                 {
-                    var anchor = AnchorIndex;
+                    var anchor = RangeAnchorIndex;
                     var i = Math.Max(_source.Rows.ModelIndexToRowIndex(anchor), 0);
                     var step = i < rowIndex ? 1 : -1;
 
@@ -174,13 +174,12 @@ namespace Avalonia.Controls.Selection
                         {
                             var m = _source.Rows.RowIndexToModelIndex(i);
                             Select(m);
+                            anchor = m;
                             if (i == rowIndex)
                                 break;
                             i += step;
                         }
                     }
-
-                    AnchorIndex = anchor;
                 }
             }
             else if (multi && toggle)

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
@@ -14,6 +14,7 @@ namespace Avalonia.Controls.Selection
         private int _count;
         private bool _singleSelect = true;
         private IndexPath _anchorIndex;
+        private IndexPath _rangeAnchorIndex;
         private IndexPath _selectedIndex;
         private Operation? _operation;
         private TreeSelectedIndexes<T>? _selectedIndexes;
@@ -70,7 +71,7 @@ namespace Avalonia.Controls.Selection
             {
                 using var update = BatchUpdate();
                 Clear();
-                Select(value);
+                Select(value, updateRangeAnchorIndex: true);
             }
         }
 
@@ -91,6 +92,18 @@ namespace Avalonia.Controls.Selection
                     return;
                 using var update = BatchUpdate();
                 update.Operation.AnchorIndex = value;
+            }
+        }
+
+        public IndexPath RangeAnchorIndex
+        {
+            get => _rangeAnchorIndex;
+            set
+            {
+                if (!TryGetItemAt(value, out _))
+                    return;
+                using var update = BatchUpdate();
+                update.Operation.RangeAnchorIndex = value;
             }
         }
 
@@ -182,29 +195,7 @@ namespace Avalonia.Controls.Selection
             return IndexRange.Contains(node?.Ranges, index[^1]);
         }
 
-        public void Select(IndexPath index)
-        {
-            if (index == default || !TryGetItemAt(index, out _))
-                return;
-
-            using var update = BatchUpdate();
-            var o = update.Operation;
-
-            if (SingleSelect)
-                Clear();
-
-            o.DeselectedRanges?.Remove(index);
-
-            if (!IsSelected(index))
-            {
-                o.SelectedRanges ??= new();
-                o.SelectedRanges.Add(index);
-            }
-
-            if (o.SelectedIndex == default)
-                o.SelectedIndex = index;
-            o.AnchorIndex = index;
-        }
+        public void Select(IndexPath index) => Select(index, updateRangeAnchorIndex: false);
 
         protected internal abstract IEnumerable<T>? GetChildren(T node);
         
@@ -397,14 +388,44 @@ namespace Avalonia.Controls.Selection
             return node;
         }
 
+        private void Select(IndexPath index, bool updateRangeAnchorIndex)
+        {
+            if (index == default || !TryGetItemAt(index, out _))
+                return;
+
+            using var update = BatchUpdate();
+            var o = update.Operation;
+
+            if (SingleSelect)
+                Clear();
+
+            o.DeselectedRanges?.Remove(index);
+
+            if (!IsSelected(index))
+            {
+                o.SelectedRanges ??= new();
+                o.SelectedRanges.Add(index);
+            }
+
+            if (o.SelectedIndex == default)
+                o.SelectedIndex = index;
+
+            o.AnchorIndex = index;
+
+            if (updateRangeAnchorIndex)
+                o.RangeAnchorIndex = index;
+        }
+
         private void CommitOperation(Operation operation)
         {
             var oldAnchorIndex = _anchorIndex;
+            var oldRangeAnchorIndex = _rangeAnchorIndex;
             var oldSelectedIndex = _selectedIndex;
             var indexesChanged = false;
 
             _selectedIndex = operation.SelectedIndex;
             _anchorIndex = operation.AnchorIndex;
+            _rangeAnchorIndex = operation.RangeAnchorIndex;
 
             if (operation.SelectedRanges is not null)
             {
@@ -447,6 +468,9 @@ namespace Avalonia.Controls.Selection
 
             if (oldAnchorIndex != _anchorIndex)
                 RaisePropertyChanged(nameof(AnchorIndex));
+
+            if (oldRangeAnchorIndex != _rangeAnchorIndex)
+                RaisePropertyChanged(nameof(RangeAnchorIndex));
 
             if (indexesChanged)
             {
@@ -549,12 +573,14 @@ namespace Avalonia.Controls.Selection
             public Operation(TreeSelectionModelBase<T> owner)
             {
                 AnchorIndex = owner.AnchorIndex;
+                RangeAnchorIndex = owner.RangeAnchorIndex;
                 SelectedIndex = owner.SelectedIndex;
             }
 
             public int UpdateCount { get; set; }
             public bool IsSourceUpdate { get; set; }
             public IndexPath AnchorIndex { get; set; }
+            public IndexPath RangeAnchorIndex { get; set; }
             public IndexPath SelectedIndex { get; set; }
             public IndexRanges? SelectedRanges { get; set; }
             public IndexRanges? DeselectedRanges { get; set; }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
@@ -561,6 +561,95 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
             }
         }
 
+        public class RangeAnchorIndex
+        {
+            [Fact]
+            public void Setting_SelectedIndex_Sets_RangeAnchorIndex()
+            {
+                var target = CreateTarget();
+                var raised = 0;
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.RangeAnchorIndex))
+                    {
+                        ++raised;
+                    }
+                };
+
+                target.SelectedIndex = new IndexPath(0, 1);
+
+                Assert.Equal(new IndexPath(0, 1), target.RangeAnchorIndex);
+                Assert.Equal(1, raised);
+            }
+
+            [Fact]
+            public void Setting_SelectedIndex_To_Empty_Doesnt_Clear_RangeAnchorIndex()
+            {
+                var target = CreateTarget();
+                var raised = 0;
+
+                target.SelectedIndex = new IndexPath(0, 1);
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.AnchorIndex))
+                    {
+                        ++raised;
+                    }
+                };
+
+                target.SelectedIndex = default;
+
+                Assert.Equal(new IndexPath(0, 1), target.RangeAnchorIndex);
+                Assert.Equal(0, raised);
+            }
+
+            [Fact]
+            public void Select_Doesnt_Set_RangeAnchorIndex()
+            {
+                var target = CreateTarget();
+                var raised = 0;
+
+                target.SelectedIndex = new IndexPath(0, 0);
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.AnchorIndex))
+                    {
+                        ++raised;
+                    }
+                };
+
+                target.Select(new IndexPath(0, 1));
+
+                Assert.Equal(new IndexPath(0, 0), target.RangeAnchorIndex);
+                Assert.Equal(1, raised);
+            }
+
+            [Fact]
+            public void Deselect_Doesnt_Clear_RangeAnchorIndex()
+            {
+                var target = CreateTarget();
+                var raised = 0;
+
+                target.SelectedIndex = new IndexPath(0, 0);
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.AnchorIndex))
+                    {
+                        ++raised;
+                    }
+                };
+
+                target.Deselect(new IndexPath(0, 0));
+
+                Assert.Equal(new IndexPath(0, 0), target.RangeAnchorIndex);
+                Assert.Equal(0, raised);
+            }
+        }
+
         public class SingleSelect
         {
             [Fact]


### PR DESCRIPTION
Previously pressing up/down arrows when selected row was scrolled offscreen would result in a random row being selected.

Instead scroll the anchor index into view and move from there.