### PR TITLE
Don't try to expand rows with no children.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
@@ -114,6 +114,9 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
         private void Expand()
         {
+            if (!_expanderColumn.HasChildren(Model))
+                return;
+
             _controller.OnBeginExpandCollapse(this);
 
             var oldExpanded = _isExpanded;

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -560,7 +560,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                     new HierarchicalExpanderColumn<Node>(
                         new TextColumn<Node, int>("ID", x => x.Id),
                         x => x.Children,
-                        x => x.Children?.Count > 0),
+                        x => x.Children is not null),
                     new TextColumn<Node, string?>("Caption", x => x.Caption),
                 }
             };


### PR DESCRIPTION
Fixes a `NotSupportedException` when pressing the right arrow over a file node in the sample.