### PR TITLE
Fix toggle modifier for OSX

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Input.Platform;
 
 namespace Avalonia.Controls.Selection
 {
@@ -117,7 +118,7 @@ namespace Avalonia.Controls.Selection
                     row.RowIndex,
                     select: true,
                     rangeModifier: e.KeyModifiers.HasFlag(KeyModifiers.Shift),
-                    toggleModifier: e.KeyModifiers.HasFlag(KeyModifiers.Control),
+                    toggleModifier: e.KeyModifiers.HasFlag(AvaloniaLocator.Current.GetService<PlatformHotkeyConfiguration>().CommandModifiers),
                     rightButton: point.Properties.IsRightButtonPressed);
                 e.Handled = true;
             }


### PR DESCRIPTION
Tested on macOS, works well for me. Shall we change it [here](https://github.com/AvaloniaUI/Avalonia.ProControls/blob/b5db31875e2c93609376e55eec22b7ba489653ef/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs#L60) to use PlatformHotkeyConfiguration/CommandModifiers too? 
Not sure where this shortcut comes from,in VS for Mac arrow up + command opens menus at the top of the window so arrows +command can not be used to prevent navigation,arrows+ctrl used to navigate between windows.
closes #59 