### PR TITLE
Update tree selection count before raising SelectionChanged.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
@@ -410,6 +410,8 @@ namespace Avalonia.Controls.Selection
                 indexesChanged |= CommitDeselect(operation.DeselectedRanges) > 0;
             }
 
+            Count += (operation.SelectedRanges?.Count ?? 0) - (operation.DeselectedRanges?.Count ?? 0);
+
             if ((SelectionChanged is not null || _untypedSelectionChanged is not null) &&
                 (operation.DeselectedRanges?.Count > 0 ||
                  operation.SelectedRanges?.Count > 0 ||
@@ -429,7 +431,6 @@ namespace Avalonia.Controls.Selection
                 _untypedSelectionChanged?.Invoke(this, e);
             }
 
-            Count += (operation.SelectedRanges?.Count ?? 0) - (operation?.DeselectedRanges?.Count ?? 0);
             _root.PruneEmptyChildren();
 
             if (oldSelectedIndex != _selectedIndex)

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
@@ -27,6 +27,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                     Assert.Equal("Node 0-2", e.DeselectedItems.Single()!.Caption);
                     Assert.Empty(e.SelectedIndexes);
                     Assert.Empty(e.SelectedItems);
+                    Assert.Equal(0, target.Count);
                     ++raised;
                 };
 
@@ -62,6 +63,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                     Assert.Empty(e.DeselectedItems);
                     Assert.Equal(new IndexPath(0, 2), e.SelectedIndexes.Single());
                     Assert.Equal("Node 0-2", e.SelectedItems.Single()!.Caption);
+                    Assert.Equal(1, target.Count);
                     ++raised;
                 };
 


### PR DESCRIPTION
Otherwise if one reads the count from the selection model in an event handler, it will be wrong.