### PR TITLE
Left arrow key press now navigates to the parent element

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using Avalonia.Controls.Utils;
 using Avalonia.Utilities;
 
@@ -139,6 +140,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public void UnrealizeCell(ICell cell, int rowIndex, int columnIndex)
         {
             (cell as IDisposable)?.Dispose();
+        }
+
+        public int GetParentRowIndex(IndexPath modelIndex)
+        {
+            return ModelIndexToRowIndex(modelIndex[..^1]);
         }
 
         public int ModelIndexToRowIndex(IndexPath modelIndex)

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
 using Avalonia.Controls.Utils;
 using Avalonia.Utilities;
 

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -88,6 +88,23 @@ namespace Avalonia.Controls.Selection
                     {
                         e.Handled = MoveSelection(sender, direction.Value, shift, anchor);
                     }
+
+                    if (!e.Handled && direction == NavigationDirection.Left
+                        && anchor?.Rows is HierarchicalRows<T> hierarchicalRows && anchorRowIndex > 0)
+                    {
+                        var newIndex = hierarchicalRows.GetParentRowIndex(AnchorIndex);
+                        UpdateSelection(sender, newIndex, true);
+                        sender.RowsPresenter.BringIntoView(newIndex);
+                        FocusManager.Instance.Focus(sender);
+                    }
+
+                    if (!e.Handled && direction == NavigationDirection.Right
+                       && anchor?.Rows is HierarchicalRows<T> hierarchicalRows2 && hierarchicalRows2[anchorRowIndex].IsExpanded)
+                    {
+                        var newIndex = anchorRowIndex + 1;
+                        UpdateSelection(sender, newIndex, true);
+                        sender.RowsPresenter.BringIntoView(newIndex);
+                    }
                 }
             }
 


### PR DESCRIPTION
This feature is specific to HierarchicalTreeDataGrid.
Hitting the left arrow key should focus the selection to the parent element.
When a node is focused, if you hit the **LEFT** arrow key, it should navigate to the parent node. 
**Example**:
![explore_configure](https://user-images.githubusercontent.com/53405089/158538675-e687d6d8-f686-4a46-88af-0e85132e16ed.gif)


Added also: Right arrow key expands a node, and if it's already expanded it navigates to the first child
Example - 
![Анимация](https://user-images.githubusercontent.com/53405089/158798688-c49d5d60-4b1d-4cde-833c-e6787aaaf6c7.gif)