### PR TITLE
Typing alphanumeric keys (a-z0-9) should focus selection on the next item whose name starts with typed input

### DIFF
--- a/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
@@ -19,7 +19,10 @@ namespace TreeDataGridDemo.ViewModels
             {
                 Columns =
                 {
-                    new TextColumn<Country, string>("Country", x => x.Name, (r, v) => r.Name = v, new GridLength(6, GridUnitType.Star)),
+                    new TextColumn<Country, string>("Country", x => x.Name, (r, v) => r.Name = v, new GridLength(6, GridUnitType.Star)) 
+                    { 
+                        IsTextSearchEnabled = true 
+                    },
                     new TextColumn<Country, string>("Region", x => x.Region, new GridLength(4, GridUnitType.Star)),
                     new TextColumn<Country, int>("Population", x => x.Population, new GridLength(3, GridUnitType.Star)),
                     new TextColumn<Country, int>("Area", x => x.Area, new GridLength(3, GridUnitType.Star)),

--- a/samples/TreeDataGridDemo/ViewModels/FilesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/FilesPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
@@ -9,13 +10,12 @@ using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Controls.Templates;
 using Avalonia.Data;
+using Avalonia.Data.Converters;
 using Avalonia.Layout;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using TreeDataGridDemo.Models;
 using ReactiveUI;
-using Avalonia.Data.Converters;
-using System.Globalization;
+using TreeDataGridDemo.Models;
 
 namespace TreeDataGridDemo.ViewModels
 {
@@ -64,7 +64,11 @@ namespace TreeDataGridDemo.ViewModels
                             {
                                 CompareAscending = FileTreeNodeModel.SortAscending(x => x.Name),
                                 CompareDescending = FileTreeNodeModel.SortDescending(x => x.Name),
-                            }),
+                            })
+                        {
+                            IsTextSearchEnabled = true,
+                            TextSearchValueSelector = x => x.Name
+                        },
                         x => x.Children,
                         x => x.IsDirectory,
                         x => x.IsExpanded),
@@ -165,7 +169,7 @@ namespace TreeDataGridDemo.ViewModels
             var path = value;
             var components = new Stack<string>();
             DirectoryInfo? d = null;
-           
+
             if (File.Exists(path))
             {
                 var f = new FileInfo(path);
@@ -214,7 +218,7 @@ namespace TreeDataGridDemo.ViewModels
         {
             var selectedPath = Source.RowSelection?.SelectedItem?.Path;
             this.RaiseAndSetIfChanged(ref _selectedPath, selectedPath, nameof(SelectedPath));
-            
+
             foreach (var i in e.DeselectedItems)
                 System.Diagnostics.Trace.WriteLine($"Deselected '{i?.Path}'");
             foreach (var i in e.SelectedItems)

--- a/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
@@ -11,6 +11,7 @@ namespace Avalonia.Controls
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
     public class FlatTreeDataGridSource<TModel> : ITreeDataGridSource<TModel>, IDisposable
+        where TModel: class
     {
         private IEnumerable<TModel> _items;
         private TreeDataGridItemsSourceView<TModel> _itemsView;

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -17,6 +17,7 @@ namespace Avalonia.Controls
     public class HierarchicalTreeDataGridSource<TModel> : ITreeDataGridSource<TModel>,
         IDisposable,
         IExpanderRowController<TModel>
+        where TModel: class
     {
         private IEnumerable<TModel> _items;
         private TreeDataGridItemsSourceView<TModel> _itemsView;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalExpanderColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalExpanderColumn.cs
@@ -68,7 +68,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         }
 
         public GridLength Width => _inner.Width;
-
+        public IColumn<TModel> Inner => _inner;
         double IUpdateColumnLayout.MinActualWidth => ((IUpdateColumnLayout)_inner).MinActualWidth;
         double IUpdateColumnLayout.MaxActualWidth => ((IUpdateColumnLayout)_inner).MaxActualWidth;
         bool IUpdateColumnLayout.StarWidthWasConstrained => ((IUpdateColumnLayout)_inner).StarWidthWasConstrained;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ISearchableTextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ISearchableTextColumn.cs
@@ -1,0 +1,8 @@
+﻿namespace Avalonia.Controls.Models.TreeDataGrid
+{
+    public interface ITextSearchableColumn<TModel>
+    {
+        public bool IsTextSearchEnabled { get; set; }
+        internal string? SelectValue(TModel model);
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumn.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
     /// <typeparam name="TValue">The column data type.</typeparam>
-    public class TemplateColumn<TModel> : ColumnBase<TModel>
+    public class TemplateColumn<TModel> : ColumnBase<TModel>, ITextSearchableColumn<TModel>
     {
         private readonly Comparison<TModel?>? _sortAscending;
         private readonly Comparison<TModel?>? _sortDescending;
@@ -31,6 +31,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// Gets the template to use to display the contents of a cell that is not in editing mode.
         /// </summary>
         public IDataTemplate? CellTemplate { get; }
+        public Func<TModel, string?>? TextSearchValueSelector { get; set; }
+        public bool IsTextSearchEnabled { get; set; }
 
         /// <summary>
         /// Creates a cell for this column on the specified row.
@@ -48,5 +50,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                 _ => null,
             };
         }
+
+        string? ITextSearchableColumn<TModel>.SelectValue(TModel model) => TextSearchValueSelector?.Invoke(model);
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
@@ -9,7 +9,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
     /// <typeparam name="TValue">The column data type.</typeparam>
-    public class TextColumn<TModel, TValue> : ColumnBase<TModel, TValue>
+    public class TextColumn<TModel, TValue> : ColumnBase<TModel, TValue>, ITextSearchableColumn<TModel>
         where TModel : class
     {
         private readonly TextTrimming _textTrimming;
@@ -61,9 +61,16 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             _textTrimming = options?.TextTrimming ?? TextTrimming.CharacterEllipsis;
         }
 
+        public bool IsTextSearchEnabled { get; set; }
+
         public override ICell CreateCell(IRow<TModel> row)
         {
             return new TextCell<TValue?>(CreateBindingExpression(row.Model), Binding.Write is null, _textTrimming);
+        }
+
+        string? ITextSearchableColumn<TModel>.SelectValue(TModel model)
+        {
+            return ValueSelector(model)?.ToString();
         }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridSelectionInteraction.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridSelectionInteraction.cs
@@ -16,6 +16,7 @@ namespace Avalonia.Controls.Selection
         bool IsRowSelected(int rowIndex);
         public void OnKeyDown(TreeDataGrid sender, KeyEventArgs e) { }
         public void OnKeyUp(TreeDataGrid sender, KeyEventArgs e) { }
+        public void OnTextInput(TreeDataGrid sender, TextInputEventArgs e) { }
         public void OnPointerPressed(TreeDataGrid sender, PointerPressedEventArgs e) { }
         public void OnPointerMoved(TreeDataGrid sender, PointerEventArgs e) { }
         public void OnPointerReleased(TreeDataGrid sender, PointerReleasedEventArgs e) { }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -144,12 +144,13 @@ namespace Avalonia.Controls.Selection
                 }
                 foreach (var column in treeDataGrid.Columns)
                 {
-                    if (column is ITextSearchableColumn<TModel> textSearchableColumn && textSearchableColumn.IsTextSearchEnabled == true)
+                    if (column is ITextSearchableColumn<TModel> textSearchableColumn && textSearchableColumn.IsTextSearchEnabled)
                     {
                         Search(treeDataGrid, candidatePattern, selectedRowIndex, textSearchableColumn);
                     }
                     else if (column is HierarchicalExpanderColumn<TModel> hierarchicalColumn &&
-                        hierarchicalColumn.Inner is ITextSearchableColumn<TModel> textSearchableColumn2)
+                        hierarchicalColumn.Inner is ITextSearchableColumn<TModel> textSearchableColumn2 &&
+                        textSearchableColumn2.IsTextSearchEnabled)
                     {
                         Search(treeDataGrid, candidatePattern, selectedRowIndex, textSearchableColumn2);
                     }

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -251,6 +251,12 @@ namespace Avalonia.Controls
             _selection?.OnKeyUp(this, e);
         }
 
+        protected override void OnTextInput(TextInputEventArgs e)
+        {
+            base.OnTextInput(e);
+            _selection?.OnTextInput(this, e);
+        }
+
         protected override void OnPointerPressed(PointerPressedEventArgs e)
         {
             base.OnPointerPressed(e);


### PR DESCRIPTION
When a node is focused, and you start typing characters, the `TreeDataGrid` should select the next node that matches the input.
Example 1. 
Press the `c` key several times:
![c-key](https://user-images.githubusercontent.com/53405089/161551078-02c92b4d-b60d-4075-ad05-5a53761d478d.gif)

Example 2. 
Press the word `code`:
![code-word](https://user-images.githubusercontent.com/53405089/161551236-d851749d-f3f9-4c7d-94d5-a05272fc89c8.gif)

**Open questions**:
Do we need a validation here and how to implement it in the best way?
I think text search makes sense to be enabled only for 1 column so it probably needs to throw an exception if you try to enable it from more than one column.

Also, I am open to suggestions about the naming :)