### PR TITLE
Double clicking column thumb should fit column contents

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnHeader.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using Avalonia.Controls.Models.TreeDataGrid;
-using Avalonia.Controls.Utils;
 using Avalonia.Input;
-using Avalonia.Layout;
 using Avalonia.Utilities;
 
 namespace Avalonia.Controls.Primitives
@@ -87,7 +85,13 @@ namespace Avalonia.Controls.Primitives
             if (_resizer is not null)
             {
                 _resizer.DragDelta += ResizerDragDelta;
+                _resizer.DoubleTapped += ResizerDoubleTapped;
             }
+        }
+
+        private void ResizerDoubleTapped(object? sender, Interactivity.RoutedEventArgs e)
+        {
+            _columns?.SetColumnWidth(ColumnIndex, GridLength.Auto);
         }
 
         protected override Size MeasureOverride(Size availableSize)


### PR DESCRIPTION
In Excel (for example) clicking the divider between two column headers resizes the left column to fit the column's contents.
![ColumnResize](https://user-images.githubusercontent.com/53405089/162167506-03a3e1da-788d-4888-b13e-13f559b3de08.gif)
I added this feature to TreeDataGrid.