### PR TITLE
Fix cannot call Measure using a size with NaN values exception in TreeDataGridColumnarPresenterBase<TItem>

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnList.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnList.cs
@@ -125,7 +125,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                 if (!column.Width.IsStar)
                 {
                     invalidated |= column.CommitActualWidth();
-                    availableSpace -= column.ActualWidth;
+                    availableSpace -= NotNaN(column.ActualWidth);
                 }
                 else
                     totalStars += column.Width.Value;

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnarPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnarPresenterBase.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Controls.Primitives
         protected sealed override Size GetFinalConstraint(IControl element, int index, Size availableSize)
         {
             var column = Columns![index];
-            return new(double.IsNaN(column.ActualWidth) ? 0.0 : column.ActualWidth, element.DesiredSize.Height);
+            return new(column.ActualWidth, element.DesiredSize.Height);
         }
 
         protected sealed override double CalculateSizeU(Size availableSize)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnarPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnarPresenterBase.cs
@@ -48,7 +48,7 @@ namespace Avalonia.Controls.Primitives
         protected sealed override Size GetFinalConstraint(IControl element, int index, Size availableSize)
         {
             var column = Columns![index];
-            return new(column.ActualWidth, element.DesiredSize.Height);
+            return new(double.IsNaN(column.ActualWidth) ? 0.0 : column.ActualWidth, element.DesiredSize.Height);
         }
 
         protected sealed override double CalculateSizeU(Size availableSize)


### PR DESCRIPTION
```
2022-04-11 12:27:15.452 [1] CRITICAL    Program.Main (86)       System.InvalidOperationException: Cannot call Measure using a size with NaN values.
   at Avalonia.Layout.Layoutable.Measure(Size availableSize) in /_/src/Avalonia.Layout/Layoutable.cs:line 351
   at Avalonia.Controls.Primitives.TreeDataGridPresenterBase`1.MeasureOverride(Size availableSize) in C:\Users\Administrator\Documents\GitHub\Avalonia.Controls.TreeDataGrid\src\Avalonia.Controls.TreeDataGrid\Primitives\TreeDataGridPresenterBase.cs:line 295
```

When the TreeDataGridColumnarPresenterBase<TItem>GetFinalConstraint is called from TreeDataGridPresenterBase.MeasureOverride `: Cannot call Measure using a size with NaN values.` exception is thrown 
https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/blob/4d1e2f23fa916c912c3bc5272ea3260ec8628e05/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs#L294

The reason is `column.ActualWidth` is `NaN`.
https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/blob/4d1e2f23fa916c912c3bc5272ea3260ec8628e05/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnarPresenterBase.cs#L51
