### PR TITLE
Setup a Tag property for the IColumn interface

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
@@ -94,6 +94,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             set => RaiseAndSetIfChanged(ref _sortDirection, value);
         }
 
+        /// <summary>
+        /// Gets or sets a user-defined object attached to the column.
+        /// </summary>
+        public object? Tag { get; set; }
+
         double IUpdateColumnLayout.MinActualWidth => CoerceActualWidth(0);
         double IUpdateColumnLayout.MaxActualWidth => CoerceActualWidth(double.PositiveInfinity);
         bool IUpdateColumnLayout.StarWidthWasConstrained => _starWidthWasConstrained;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalExpanderColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalExpanderColumn.cs
@@ -67,6 +67,15 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             set => _inner.SortDirection = value;
         }
 
+        /// <summary>
+        /// Gets or sets a user-defined object attached to the column.
+        /// </summary>
+        public object? Tag
+        {
+            get => _inner.Tag;
+            set => _inner.Tag = value;
+        }
+
         public GridLength Width => _inner.Width;
         public IColumn<TModel> Inner => _inner;
         double IUpdateColumnLayout.MinActualWidth => ((IUpdateColumnLayout)_inner).MinActualWidth;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/IColumn.cs
@@ -42,5 +42,10 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// <see cref="ITreeDataGridSource.SortBy(IColumn, ListSortDirection)"/>.
         /// </remarks>
         ListSortDirection? SortDirection { get; set; }
+
+        /// <summary>
+        /// Gets or sets a user-defined object attached to the column.
+        /// </summary>
+        object? Tag { get; set; }
     }
 }


### PR DESCRIPTION
This PR defines an `object Tag` property for the `IColumn` interface.

We found some scenarios in which we found it useful to put user-defined data in the column, so you can later access them when exploring the TreeDataGrid's columns.