### PR TITLE
Make styles more flexible

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml
@@ -8,19 +8,22 @@
     <StreamGeometry x:Key="TreeDataGridGridSortIconDescendingPath">M1875 1011l-787 787v-1798h-128v1798l-787 -787l-90 90l941 941l941 -941z</StreamGeometry>
     <StreamGeometry x:Key="TreeDataGridGridSortIconAscendingPath">M1965 947l-941 -941l-941 941l90 90l787 -787v1798h128v-1798l787 787z</StreamGeometry>
   </Styles.Resources>
+
   <Style Selector="TreeDataGrid">
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Background="{TemplateBinding Background}"
+        <Border x:Name="RootBorder"
+                Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="{TemplateBinding BorderThickness}">
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
           <DockPanel>
             <ScrollViewer DockPanel.Dock="Top"
                           IsVisible="{TemplateBinding ShowColumnHeaders}"
                           Offset="{Binding Scroll.Offset, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                           HorizontalScrollBarVisibility="Hidden"
                           VerticalScrollBarVisibility="Disabled">
-              <Border BorderThickness="0 0 0 1" BorderBrush="{DynamicResource TreeDataGridGridLinesBrush}">
+              <Border x:Name="ColumnHeadersPresenterBorder">
                 <TreeDataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
                                                     ElementFactory="{TemplateBinding ElementFactory}"
                                                     Items="{TemplateBinding Columns}"/>
@@ -40,6 +43,11 @@
     </Setter>
   </Style>
 
+  <Style Selector="TreeDataGrid /template/ Border#ColumnHeadersPresenterBorder">
+    <Setter Property="BorderThickness" Value="0 0 0 1" />
+    <Setter Property="BorderBrush" Value="{DynamicResource TreeDataGridGridLinesBrush}" />
+  </Style>
+
   <Style Selector="TreeDataGridColumnHeader">
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="MinHeight" Value="25"/>
@@ -47,12 +55,14 @@
     <Setter Property="VerticalContentAlignment" Value="Center"/>
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Name="border"
+        <Border Name="DataGridBorder"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
-                BorderThickness="{TemplateBinding BorderThickness}">
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
           <DockPanel VerticalAlignment="Stretch">
-            <Panel DockPanel.Dock="Right">
+            <Panel DockPanel.Dock="Right"
+                   TabIndex="2">
               <Rectangle Fill="{DynamicResource TreeDataGridGridLinesBrush}"
                          HorizontalAlignment="Right"
                          Width="1"/>
@@ -76,32 +86,34 @@
                   HorizontalAlignment="Center"
                   VerticalAlignment="Center"
                   Stretch="Uniform"
-                  Height="12" />
-              <ContentPresenter Name="PART_ContentPresenter"
-                                Content="{TemplateBinding Header}"
-                                ContentTemplate="{TemplateBinding ContentTemplate}"
-                                Padding="{TemplateBinding Padding}"
-                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}">
-                  <ContentPresenter.DataTemplates>
-                      <DataTemplate DataType="x:String">
-                          <TextBlock Text="{Binding}" TextTrimming="CharacterEllipsis"/>
-                      </DataTemplate>
-                  </ContentPresenter.DataTemplates>
-              </ContentPresenter>
+                  Height="12"
+                  TabIndex="1" />
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Content="{TemplateBinding Header}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              Padding="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                              TabIndex="0">
+                <ContentPresenter.DataTemplates>
+                    <DataTemplate DataType="x:String">
+                        <TextBlock Text="{Binding}" TextTrimming="CharacterEllipsis"/>
+                    </DataTemplate>
+                </ContentPresenter.DataTemplates>
+            </ContentPresenter>
           </DockPanel>
         </Border>
       </ControlTemplate>
     </Setter>
   </Style>
 
-  <Style Selector="TreeDataGridColumnHeader:pointerover /template/ Border#border">
+  <Style Selector="TreeDataGridColumnHeader:pointerover /template/ Border#DataGridBorder">
     <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPointerOver}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPointerOver}" />
     <Setter Property="TextBlock.Foreground" Value="{DynamicResource ButtonForegroundPointerOver}" />
   </Style>
 
-  <Style Selector="TreeDataGridColumnHeader:pressed /template/ Border#border">
+  <Style Selector="TreeDataGridColumnHeader:pressed /template/ Border#DataGridBorder">
     <Setter Property="Background" Value="{DynamicResource ButtonBackgroundPressed}" />
     <Setter Property="BorderBrush" Value="{DynamicResource ButtonBorderBrushPressed}" />
     <Setter Property="TextBlock.Foreground" Value="{DynamicResource ButtonForegroundPressed}" />
@@ -120,7 +132,11 @@
   <Style Selector="TreeDataGridExpanderCell">
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Background="{TemplateBinding Background}"
+        <Border x:Name="CellBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
                 Padding="{TemplateBinding Indent, Converter={x:Static conv:IndentConverter.Instance}}">
           <DockPanel>
             <Border DockPanel.Dock="Left"
@@ -141,7 +157,11 @@
   <Style Selector="TreeDataGridRow">
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Background="{TemplateBinding Background}">
+        <Border x:Name="RowBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
           <TreeDataGridCellsPresenter Name="PART_CellsPresenter"
                                       ElementFactory="{TemplateBinding ElementFactory}"
                                       Items="{TemplateBinding Columns}"
@@ -152,9 +172,15 @@
   </Style>
   
   <Style Selector="TreeDataGridTextCell">
+    <Setter Property="Padding" Value="4 2" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Background="{TemplateBinding Background}" Padding="4 2">
+        <Border x:Name="CellBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
           <TextBlock Text="{TemplateBinding Value}"
                      TextTrimming="{TemplateBinding TextTrimming}"
                      VerticalAlignment="Center"/>
@@ -164,18 +190,32 @@
   </Style>
 
   <Style Selector="TreeDataGridTextCell:editing">
+    <Setter Property="Padding" Value="4 2" />
     <Setter Property="Template">
       <ControlTemplate>
-        <Border Background="{TemplateBinding Background}" Padding="4 2">
+        <Border x:Name="CellBorder"
+                Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
+                Padding="{TemplateBinding Padding}">
           <TextBox Name="PART_Edit"
-                   Background="Transparent"
-                   MinHeight="25"
-                   Padding="10,3,6,3"
-                   Text="{Binding DataContext.Value, RelativeSource={RelativeSource TemplatedParent}}"
-                   VerticalAlignment="Center"/>
+                   Text="{Binding Value, RelativeSource={RelativeSource TemplatedParent}}" />
         </Border>
       </ControlTemplate>
     </Setter>
+  </Style>
+
+  <Style Selector="TreeDataGridTextCell:editing /template/ TextBox#PART_Edit">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="MinHeight" Value="25" />
+    <Setter Property="Padding" Value="10,3,6,3" />
+    <Setter Property="VerticalAlignment" Value="Center" />
+  </Style>
+
+  <Style Selector="TreeDataGridTextCell:editing /template/ TextBox#PART_Edit DataValidationErrors">
+    <Setter Property="Template" Value="{DynamicResource TooltipDataValidationContentTemplate}" />
+    <Setter Property="ErrorTemplate" Value="{DynamicResource TooltipDataValidationErrorTemplate}" />
   </Style>
 
   <Style Selector="TreeDataGridTemplateCell">
@@ -186,6 +226,7 @@
                           BorderBrush="{TemplateBinding BorderBrush}"
                           BorderThickness="{TemplateBinding BorderThickness}"
                           ContentTemplate="{TemplateBinding ContentTemplate}"
+                          CornerRadius="{TemplateBinding CornerRadius}"
                           Content="{TemplateBinding Content}"
                           Padding="{TemplateBinding Padding}"/>
       </ControlTemplate>


### PR DESCRIPTION
Changes:
1. Be sure that root element has name on it, so it's easier to access it.
2. All common elements (cell, header, row) should have template bindings to "big 4 properties":  Background, BorderBrush, BorderThickness and CornerRadius. So, it's easier to style these elements.
3. No hardcoded properties with local value, that likely to be restyled.
4. TabIndex should be set when we use DockPanel.
5. Set "tooltip/compact" style on DataValidationErrors of editable text cell.
6. "TreeDataGridTextCell:editing" had wrong Text binding, breaking editable mode (F2).