### PR TITLE
Fix a few problems in TreeSelectionModelBase.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
@@ -304,7 +304,8 @@ namespace Avalonia.Controls.Selection
                 _untypedSelectionChanged?.Invoke(this, e);
             }
 
-            Count += (raiseIndexesChanged ? shiftDelta : 0) - (removed?.Count ?? 0);
+            if (removed?.Count > 0)
+                Count -= removed.Count;
 
             if (selectedIndexChanged)
                 RaisePropertyChanged(nameof(SelectedIndex));
@@ -320,7 +321,7 @@ namespace Avalonia.Controls.Selection
                 OnSourceCollectionChangeFinished();
         }
 
-        protected internal virtual void OnNodeCollectionReset(IndexPath parentIndex)
+        protected internal virtual void OnNodeCollectionReset(IndexPath parentIndex, int removeCount)
         {
             var selectedIndexChanged = false;
             var anchorIndexChanged = false;
@@ -334,6 +335,7 @@ namespace Avalonia.Controls.Selection
                 selectedIndexChanged = selectedItemChanged = true;
             }
 
+            Count -= removeCount;
             SourceReset?.Invoke(this, new TreeSelectionModelSourceResetEventArgs(parentIndex));
 
             if (selectedIndexChanged)

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
@@ -285,13 +285,14 @@ namespace Avalonia.Controls.Selection
             }
 
             // Shift or clear the selected and anchor indexes according to the shift index/delta.
+            var hadSelection = _selectedIndex != default;
             var selectedIndexChanged = ShiftIndex(parentIndex, shiftIndex, shiftDelta, ref _selectedIndex);
             var anchorIndexChanged = ShiftIndex(parentIndex, shiftIndex, shiftDelta, ref _anchorIndex);
             var selectedItemChanged = false;
 
             // Check that the selected index is still selected in the node. It can get
             // unselected as the result of a replace operation.
-            if (_selectedIndex != default && !IsSelected(_selectedIndex))
+            if (hadSelection && !IsSelected(_selectedIndex))
             {
                 _selectedIndex = GetFirstSelectedIndex(_root);
                 selectedIndexChanged = selectedItemChanged = true;

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionNode.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionNode.cs
@@ -194,6 +194,13 @@ namespace Avalonia.Controls.Selection
         protected override void OnSourceReset()
         {
             var removed = CommitDeselect(new IndexRange(0, int.MaxValue));
+
+            if (_children is not null)
+            {
+                foreach (var child in _children)
+                    child?.AncestorReset(ref removed);
+            }
+
             _owner.OnNodeCollectionReset(Path, removed);
         }
 
@@ -230,6 +237,22 @@ namespace Avalonia.Controls.Selection
             {
                 foreach (var child in _children)
                     child?.AncestorRemoved(ref removed);
+            }
+
+            Source = null;
+        }
+
+        private void AncestorReset(ref int removedCount)
+        {
+            if (Ranges.Count > 0)
+            {
+                removedCount += CommitDeselect(0, int.MaxValue);
+            }
+
+            if (_children is not null)
+            {
+                foreach (var child in _children)
+                    child?.AncestorReset(ref removedCount);
             }
 
             Source = null;

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionNode.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionNode.cs
@@ -193,8 +193,8 @@ namespace Avalonia.Controls.Selection
 
         protected override void OnSourceReset()
         {
-            CommitDeselect(new IndexRange(0, int.MaxValue));
-            _owner.OnNodeCollectionReset(Path);
+            var removed = CommitDeselect(new IndexRange(0, int.MaxValue));
+            _owner.OnNodeCollectionReset(Path, removed);
         }
 
         private void AncestorIndexChanged(IndexPath parentIndex, int shiftIndex, int shiftDelta)

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionNode.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionNode.cs
@@ -199,6 +199,7 @@ namespace Avalonia.Controls.Selection
             {
                 foreach (var child in _children)
                     child?.AncestorReset(ref removed);
+                _children = null;
             }
 
             _owner.OnNodeCollectionReset(Path, removed);

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Collections/ResettingCollection.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Collections/ResettingCollection.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace Avalonia.Controls.TreeDataGridTests.Collections
+{
+    internal class ResettingCollection<T> : List<T>, INotifyCollectionChanged
+    {
+        public ResettingCollection(IEnumerable<T> items)
+        {
+            AddRange(items);
+        }
+
+        public new void RemoveAt(int index)
+        {
+            var item = this[index];
+            base.RemoveAt(index);
+            CollectionChanged?.Invoke(
+                this,
+                new NotifyCollectionChangedEventArgs(
+                    NotifyCollectionChangedAction.Remove,
+                    item,
+                    index));
+        }
+
+        public void Reset(IEnumerable<T> items)
+        {
+            Clear();
+            AddRange(items);
+            CollectionChanged?.Invoke(
+                this,
+                new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+    }
+}

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
@@ -31,6 +31,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.SelectedIndex = new IndexPath(0, 2);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -56,6 +57,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.SelectedIndex = new IndexPath(0, 0, 2);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-0-2", target.SelectedItem!.Caption);
@@ -81,6 +83,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.SelectedIndex = new IndexPath(0, 2);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -106,6 +109,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.SelectedIndex = default;
 
                 Assert.Equal(1, raised);
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -131,6 +135,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.SelectedIndex = new IndexPath(5, 10, 250);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -155,6 +160,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.SelectedIndex = new IndexPath(1, 2);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(1, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 1-2", target.SelectedItem!.Caption);
@@ -251,6 +257,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.Select(new IndexPath(1, 2));
                 target.Select(new IndexPath(2, 3));
 
+                Assert.Equal(4, target.Count);
                 Assert.Equal(4, target.SelectedIndexes.Count);
                 Assert.Equal(new IndexPath(0), target.SelectedIndexes[0]);
                 Assert.Equal(new IndexPath(1), target.SelectedIndexes[1]);
@@ -290,6 +297,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.Select(new IndexPath(1, 2));
                 target.Select(new IndexPath(2, 3));
 
+                Assert.Equal(4, target.Count);
                 Assert.Equal(4, target.SelectedItems.Count);
                 Assert.Equal("Node 0", target.SelectedItems[0]!.Caption);
                 Assert.Equal("Node 1", target.SelectedItems[1]!.Caption);
@@ -337,6 +345,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.Select(new IndexPath(0, 2));
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -363,6 +372,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.Select(new IndexPath(0, 2));
 
                 Assert.Equal(1, raised);
+                Assert.Equal(2, target.Count);
                 Assert.Equal(new IndexPath(0), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0), new IndexPath(0, 2) }, target.SelectedIndexes);
                 Assert.Equal("Node 0", target.SelectedItem!.Caption);
@@ -381,6 +391,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.Select(new IndexPath(5, 10, 250));
 
                 Assert.Equal(0, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -424,6 +435,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 target.Deselect(new IndexPath(0, 1));
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0", target.SelectedItem!.Caption);
@@ -441,6 +453,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.Select(new IndexPath(0, 5));
                 target.Deselect(new IndexPath(0, 3));
 
+                Assert.Equal(3, target.Count);
                 Assert.Equal(new IndexPath(0, 4), target.SelectedIndex);
             }
         }
@@ -674,6 +687,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 target.SingleSelect = true;
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-1", target.SelectedItem!.Caption);
@@ -734,6 +748,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.Insert(0, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(2), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(2) }, target.SelectedIndexes);
                 Assert.Equal("Node 1", target.SelectedItem!.Caption);
@@ -775,6 +790,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data[0].Children!.Insert(0, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0, 2) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-1", target.SelectedItem!.Caption);
@@ -816,6 +832,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.Insert(0, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-1", target.SelectedItem!.Caption);
@@ -857,6 +874,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.Insert(0, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1, 0, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1, 0, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-0-1", target.SelectedItem!.Caption);
@@ -882,6 +900,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.Insert(2, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1) }, target.SelectedIndexes);
                 Assert.Equal("Node 1", target.SelectedItem!.Caption);
@@ -919,6 +938,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.RemoveAt(1);
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -957,6 +977,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data[0].Children!.RemoveAt(1);
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -995,6 +1016,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.RemoveAt(0);
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -1025,6 +1047,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.RemoveAt(0);
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0) }, target.SelectedIndexes);
                 Assert.Equal("Node 1", target.SelectedItem!.Caption);
@@ -1055,6 +1078,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.RemoveAt(0);
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 1-1", target.SelectedItem!.Caption);
@@ -1085,6 +1109,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data[1].Children!.RemoveAt(0);
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1, 0, 2), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1, 0, 2) }, target.SelectedIndexes);
                 Assert.Equal("Node 1-1-2", target.SelectedItem!.Caption);
@@ -1109,6 +1134,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.RemoveAt(2);
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1) }, target.SelectedIndexes);
                 Assert.Equal("Node 1", target.SelectedItem!.Caption);
@@ -1152,6 +1178,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data[1] = new Node { Caption = "new" };
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -1196,6 +1223,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data[1].Children![1] = new Node { Caption = "new" };
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -1239,6 +1267,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.Clear();
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -1282,6 +1311,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data[1].Children!.Clear();
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -1326,6 +1356,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data[1].Children!.Clear();
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(2, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(2, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 2-1", target.SelectedItem!.Caption);
@@ -1358,6 +1389,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 data.Add(new Node { Caption = "foo" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0) }, target.SelectedIndexes);
                 Assert.Equal("foo", target.SelectedItem!.Caption);

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
@@ -1452,6 +1452,37 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 Assert.Null(debug.GetCollectionChangedSubscribers());
             }
+
+            [Fact]
+            public void Clearing_Children_Updates_State()
+            {
+                var data = CreateData(depth: 3);
+                var target = CreateTarget(data);
+                var selectionChangedRaised = 0;
+                var sourceResetRaised = 0;
+                var indexesChangedraised = 0;
+
+                target.Select(new IndexPath(0, 1));
+                target.Select(new IndexPath(0, 2));
+                target.Select(new IndexPath(0, 3));
+                target.Select(new IndexPath(1, 3));
+
+                target.SelectionChanged += (s, e) => ++selectionChangedRaised;
+                target.SourceReset += (s, e) => ++sourceResetRaised;
+                target.IndexesChanged += (s, e) => ++indexesChangedraised;
+
+                data[0].Children!.Clear();
+
+                Assert.Equal(1, target.Count);
+                Assert.Equal(new IndexPath(1, 3), target.SelectedIndex);
+                Assert.Equal(new[] { new IndexPath(1, 3) }, target.SelectedIndexes);
+                Assert.Equal("Node 1-3", target.SelectedItem!.Caption);
+                Assert.Equal(new[] { "Node 1-3" }, target.SelectedItems.Select(x => x!.Caption));
+                Assert.Equal(new IndexPath(1, 3), target.AnchorIndex);
+                Assert.Equal(0, indexesChangedraised);
+                Assert.Equal(0, selectionChangedRaised);
+                Assert.Equal(1, sourceResetRaised);
+            }
         }
 
         private static AvaloniaList<Node> CreateNodes(IndexPath parentId, int depth = 2)

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
@@ -1456,13 +1456,15 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
             [Fact]
             public void Clearing_Children_Updates_State()
             {
-                var data = CreateData(depth: 3);
+                var data = CreateData(depth: 4);
                 var target = CreateTarget(data);
                 var selectionChangedRaised = 0;
                 var sourceResetRaised = 0;
                 var indexesChangedraised = 0;
 
                 target.Select(new IndexPath(0, 1));
+                target.Select(new IndexPath(0, 1, 0));
+                target.Select(new IndexPath(0, 1, 0, 1));
                 target.Select(new IndexPath(0, 2));
                 target.Select(new IndexPath(0, 3));
                 target.Select(new IndexPath(1, 3));

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
@@ -448,13 +448,13 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
             {
                 var target = CreateTarget();
 
+                target.Select(new IndexPath(0, 2));
                 target.Select(new IndexPath(0, 3));
                 target.Select(new IndexPath(0, 4));
-                target.Select(new IndexPath(0, 5));
-                target.Deselect(new IndexPath(0, 3));
+                target.Deselect(new IndexPath(0, 2));
 
-                Assert.Equal(3, target.Count);
-                Assert.Equal(new IndexPath(0, 4), target.SelectedIndex);
+                Assert.Equal(2, target.Count);
+                Assert.Equal(new IndexPath(0, 3), target.SelectedIndex);
             }
         }
 

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
@@ -1120,6 +1120,46 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
             }
 
             [Fact]
+            public void Removing_Child_Range_Updates_State()
+            {
+                var data = CreateData(depth: 3);
+                var target = CreateTarget(data);
+                var selectionChangedRaised = 0;
+                var indexesChangedraised = 0;
+
+                target.Select(new IndexPath(0, 1));
+                target.Select(new IndexPath(0, 2));
+                target.Select(new IndexPath(0, 3));
+
+                target.SelectionChanged += (s, e) =>
+                {
+                    Assert.Empty(e.DeselectedIndexes);
+                    Assert.Equal(new[] { "Node 0-1" }, e.DeselectedItems.Select(x => x!.Caption));
+                    Assert.Empty(e.SelectedIndexes);
+                    Assert.Empty(e.SelectedItems);
+                    ++selectionChangedRaised;
+                };
+
+                target.IndexesChanged += (s, e) =>
+                {
+                    Assert.Equal(0, e.StartIndex);
+                    Assert.Equal(-2, e.Delta);
+                    ++indexesChangedraised;
+                };
+
+                data[0].Children!.RemoveRange(0, 2);
+
+                Assert.Equal(2, target.Count);
+                Assert.Equal(new IndexPath(0, 0), target.SelectedIndex);
+                Assert.Equal(new[] { new IndexPath(0, 0), new IndexPath(0, 1) }, target.SelectedIndexes);
+                Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
+                Assert.Equal(new[] { "Node 0-2", "Node 0-3" }, target.SelectedItems.Select(x => x!.Caption));
+                Assert.Equal(new IndexPath(0, 1), target.AnchorIndex);
+                Assert.Equal(1, indexesChangedraised);
+                Assert.Equal(1, selectionChangedRaised);
+            }
+
+            [Fact]
             public void Removing_Root_Item_After_Selected_Root_Item_Doesnt_Raise_Events()
             {
                 var data = CreateData();

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
@@ -33,6 +33,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 target.Source = CreateData(depth: 1);
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(-1, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -70,6 +71,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.SelectedIndex = new IndexPath(0, 2);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -95,6 +97,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.SelectedIndex = new IndexPath(0, 0, 2);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-0-2", target.SelectedItem!.Caption);
@@ -120,6 +123,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.SelectedIndex = new IndexPath(0, 2);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -145,6 +149,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.SelectedIndex = default;
 
                 Assert.Equal(1, raised);
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -170,6 +175,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.SelectedIndex = new IndexPath(5, 10, 250);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -194,6 +200,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.SelectedIndex = new IndexPath(1, 2);
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(1, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 1-2", target.SelectedItem!.Caption);
@@ -342,6 +349,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.Select(new IndexPath(0, 2));
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -368,6 +376,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.Select(new IndexPath(0, 2));
 
                 Assert.Equal(1, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -386,6 +395,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.Select(new IndexPath(5, 10, 250));
 
                 Assert.Equal(0, raised);
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndexes.Single());
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
@@ -428,6 +438,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 target.Deselect(new IndexPath(0, 1));
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -445,6 +456,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 target.SelectionChanged += (s, e) => ++raised;
                 target.Deselect(new IndexPath(0, 0));
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-1", target.SelectedItem!.Caption);
@@ -598,6 +610,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 target.SingleSelect = false;
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-1", target.SelectedItem!.Caption);
@@ -658,6 +671,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.Insert(0, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(2), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(2) }, target.SelectedIndexes);
                 Assert.Equal("Node 1", target.SelectedItem!.Caption);
@@ -699,6 +713,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data[0].Children!.Insert(0, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 2), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0, 2) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-1", target.SelectedItem!.Caption);
@@ -740,6 +755,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.Insert(0, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-1", target.SelectedItem!.Caption);
@@ -781,6 +797,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.Insert(0, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1, 0, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1, 0, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 0-0-1", target.SelectedItem!.Caption);
@@ -806,6 +823,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.Insert(2, new Node { Caption = "new" });
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1) }, target.SelectedIndexes);
                 Assert.Equal("Node 1", target.SelectedItem!.Caption);
@@ -843,6 +861,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.RemoveAt(1);
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -881,6 +900,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data[0].Children!.RemoveAt(1);
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -919,6 +939,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.RemoveAt(0);
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -949,6 +970,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.RemoveAt(0);
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0) }, target.SelectedIndexes);
                 Assert.Equal("Node 1", target.SelectedItem!.Caption);
@@ -979,6 +1001,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.RemoveAt(0);
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(0, 1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(0, 1) }, target.SelectedIndexes);
                 Assert.Equal("Node 1-1", target.SelectedItem!.Caption);
@@ -1009,6 +1032,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data[1].Children!.RemoveAt(0);
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1, 0, 2), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1, 0, 2) }, target.SelectedIndexes);
                 Assert.Equal("Node 1-1-2", target.SelectedItem!.Caption);
@@ -1033,6 +1057,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data.RemoveAt(2);
 
+                Assert.Equal(1, target.Count);
                 Assert.Equal(new IndexPath(1), target.SelectedIndex);
                 Assert.Equal(new[] { new IndexPath(1) }, target.SelectedIndexes);
                 Assert.Equal("Node 1", target.SelectedItem!.Caption);
@@ -1076,6 +1101,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data[1] = new Node { Caption = "new" };
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);
@@ -1120,6 +1146,7 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 data[1].Children![1] = new Node { Caption = "new" };
 
+                Assert.Equal(0, target.Count);
                 Assert.Equal(default, target.SelectedIndex);
                 Assert.Empty(target.SelectedIndexes);
                 Assert.Null(target.SelectedItem);


### PR DESCRIPTION
- `Count` property was not being correctly updated in all cases
- Resetting a collection was not clearing child selection in all cases