### PR TITLE
Fixed IsReadOnly property in CheckBoxCell

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCheckBoxCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCheckBoxCell.cs
@@ -8,9 +8,9 @@ namespace Avalonia.Controls.Primitives
     {
         public static readonly DirectProperty<TreeDataGridCheckBoxCell, bool> IsReadOnlyProperty =
             AvaloniaProperty.RegisterDirect<TreeDataGridCheckBoxCell, bool>(
-                nameof(IsThreeState),
-                o => o.IsThreeState,
-                (o, v) => o.IsThreeState = v);
+                nameof(IsReadOnly),
+                o => o.IsReadOnly,
+                (o, v) => o.IsReadOnly = v);
 
         public static readonly DirectProperty<TreeDataGridCheckBoxCell, bool> IsThreeStateProperty =
             AvaloniaProperty.RegisterDirect<TreeDataGridCheckBoxCell, bool>(


### PR DESCRIPTION
Fixed `IsReadOnly` property in `TreeDataGridCheckBoxCell`. Clearly a copy/paste bug.