### PR TITLE
Correctly raise the RowDrop event.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -583,7 +583,7 @@ namespace Avalonia.Controls
 
             if (route.HasHandlers)
             {
-                var ev = new TreeDataGridRowDragEventArgs(row, e);
+                var ev = new TreeDataGridRowDragEventArgs(RowDragOverEvent, row, e);
                 ev.Position = adorner;
                 RaiseEvent(ev);
                 adorner = ev.Position;
@@ -618,7 +618,7 @@ namespace Avalonia.Controls
 
             if (route.HasHandlers)
             {
-                var ev = new TreeDataGridRowDragEventArgs(row, e);
+                var ev = new TreeDataGridRowDragEventArgs(RowDropEvent, row, e);
                 ev.Position = position;
                 RaiseEvent(ev);
 

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGridRowDragEventArgs.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGridRowDragEventArgs.cs
@@ -21,10 +21,11 @@ namespace Avalonia.Controls
         /// <summary>
         /// Initializes a new instance of the <see cref="TreeDataGridRowDragEventArgs"/> class.
         /// </summary>
+        /// <param name="routedEvent">The event being raised.</param>
         /// <param name="row">The row that is being dragged over.</param>
         /// <param name="inner">The inner drag event args.</param>
-        public TreeDataGridRowDragEventArgs(TreeDataGridRow row, DragEventArgs inner)
-            : base(TreeDataGrid.RowDragOverEvent)
+        public TreeDataGridRowDragEventArgs(RoutedEvent routedEvent, TreeDataGridRow row, DragEventArgs inner)
+            : base(routedEvent)
         {
             TargetRow = row;
             Inner = inner;


### PR DESCRIPTION
We were previously always raising `RowDragOver`, even for row drops.