### PR TITLE
Update actions dotnet SDK version.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,16 +6,14 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: ['6.0.x' ]
-
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: | 
+            6.0.x
+            7.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build


### PR DESCRIPTION
#149 updated the dotnet SDK version in global.json but didn't update the version in the GitHub actions workflow. Update that to make GitHub actions work again.