### PR TITLE
WIP: Move some properties to column options

### DIFF
--- a/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
@@ -19,10 +19,10 @@ namespace TreeDataGridDemo.ViewModels
             {
                 Columns =
                 {
-                    new TextColumn<Country, string>("Country", x => x.Name, (r, v) => r.Name = v, new GridLength(6, GridUnitType.Star)) 
+                    new TextColumn<Country, string>("Country", x => x.Name, (r, v) => r.Name = v, new GridLength(6, GridUnitType.Star), new()
                     { 
                         IsTextSearchEnabled = true 
-                    },
+                    }),
                     new TextColumn<Country, string>("Region", x => x.Region, new GridLength(4, GridUnitType.Star)),
                     new TextColumn<Country, int>("Population", x => x.Population, new GridLength(3, GridUnitType.Star)),
                     new TextColumn<Country, int>("Area", x => x.Area, new GridLength(3, GridUnitType.Star)),

--- a/samples/TreeDataGridDemo/ViewModels/FilesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/FilesPageViewModel.cs
@@ -45,7 +45,7 @@ namespace TreeDataGridDemo.ViewModels
                         null,
                         x => x.IsChecked,
                         (o, v) => o.IsChecked = v,
-                        options: new ColumnOptions<FileTreeNodeModel>
+                        options: new()
                         {
                             CanUserResizeColumn = false,
                         }),

--- a/samples/TreeDataGridDemo/ViewModels/FilesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/FilesPageViewModel.cs
@@ -54,22 +54,20 @@ namespace TreeDataGridDemo.ViewModels
                             "Name",
                             "FileNameCell",
                             new GridLength(1, GridUnitType.Star),
-                            new ColumnOptions<FileTreeNodeModel>
+                            new()
                             {
                                 CompareAscending = FileTreeNodeModel.SortAscending(x => x.Name),
                                 CompareDescending = FileTreeNodeModel.SortDescending(x => x.Name),
-                            })
-                        {
-                            IsTextSearchEnabled = true,
-                            TextSearchValueSelector = x => x.Name
-                        },
+                                IsTextSearchEnabled = true,
+                                TextSearchValueSelector = x => x.Name
+                            }),
                         x => x.Children,
                         x => x.HasChildren,
                         x => x.IsExpanded),
                     new TextColumn<FileTreeNodeModel, long?>(
                         "Size",
                         x => x.Size,
-                        options: new TextColumnOptions<FileTreeNodeModel>
+                        options: new()
                         {
                             CompareAscending = FileTreeNodeModel.SortAscending(x => x.Size),
                             CompareDescending = FileTreeNodeModel.SortDescending(x => x.Size),
@@ -77,7 +75,7 @@ namespace TreeDataGridDemo.ViewModels
                     new TextColumn<FileTreeNodeModel, DateTimeOffset?>(
                         "Modified",
                         x => x.Modified,
-                        options: new TextColumnOptions<FileTreeNodeModel>
+                        options: new()
                         {
                             CompareAscending = FileTreeNodeModel.SortAscending(x => x.Modified),
                             CompareDescending = FileTreeNodeModel.SortDescending(x => x.Modified),

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxCell.cs
@@ -33,6 +33,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         }
 
         public bool CanEdit => false;
+        public bool SingleTapEdit => false;
         public bool IsReadOnly { get; }
         public bool IsThreeState { get; }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxColumn.cs
@@ -31,7 +31,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             Expression<Func<TModel, bool>> getter,
             Action<TModel, bool>? setter = null,
             GridLength? width = null,
-            ColumnOptions<TModel>? options = null)
+            CheckBoxColumnOptions<TModel>? options = null)
             : base(header, ToNullable(getter), ToNullable(getter, setter), width, options)
         {
         }
@@ -58,7 +58,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             Expression<Func<TModel, bool?>> getter,
             Action<TModel, bool?>? setter = null,
             GridLength? width = null,
-            ColumnOptions<TModel>? options = null)
+            CheckBoxColumnOptions<TModel>? options = null)
             : base(header, getter, setter, width, options ?? new())
         {
             IsThreeState = true;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxColumn.cs
@@ -59,7 +59,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             Action<TModel, bool?>? setter = null,
             GridLength? width = null,
             ColumnOptions<TModel>? options = null)
-            : base(header, getter, setter, width, options)
+            : base(header, getter, setter, width, options ?? new())
         {
             IsThreeState = true;
         }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxColumnOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxColumnOptions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Avalonia.Controls.Models.TreeDataGrid
+{
+    /// <summary>
+    /// Holds less commonly-used options for a <see cref="CheckBoxColumn{TModel}"/>.
+    /// </summary>
+    /// <typeparam name="TModel">The model type.</typeparam>
+    public class CheckBoxColumnOptions<TModel> : ColumnOptions<TModel>
+    {
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
@@ -11,10 +11,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     public abstract class ColumnBase<TModel> : NotifyingBase, IColumn<TModel>, IUpdateColumnLayout
     {
         private double _actualWidth = double.NaN;
-        private bool? _canUserResize;
         private GridLength _width;
-        private GridLength? _minWidth;
-        private GridLength? _maxWidth;
         private double _autoWidth = double.NaN;
         private double _starWidth = double.NaN;
         private bool _starWidthWasConstrained;
@@ -32,12 +29,10 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public ColumnBase(
             object? header,
             GridLength? width,
-            ColumnOptions<TModel>? options)
-        {
-            _canUserResize = options?.CanUserResizeColumn;
-            _minWidth = options?.MinWidth ?? new GridLength(30, GridUnitType.Pixel);
-            _maxWidth = options?.MaxWidth;
+            ColumnOptions<TModel> options)
+        {            
             _header = header;
+            Options = options;
             SetWidth(width ?? GridLength.Auto);
         }
 
@@ -48,15 +43,6 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         {
             get => _actualWidth;
             private set => RaiseAndSetIfChanged(ref _actualWidth, value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the user can resize the column.
-        /// </summary>
-        public bool? CanUserResize
-        {
-            get => _canUserResize;
-            set => RaiseAndSetIfChanged(ref _canUserResize, value);
         }
 
         /// <summary>
@@ -81,6 +67,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         }
 
         /// <summary>
+        /// Gets the column options.
+        /// </summary>
+        public ColumnOptions<TModel> Options { get; }
+
+        /// <summary>
         /// Gets or sets the sort direction indicator that will be displayed on the column.
         /// </summary>
         /// <remarks>
@@ -99,6 +90,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// </summary>
         public object? Tag { get; set; }
 
+        bool? IColumn.CanUserResize => Options.CanUserResizeColumn;
         double IUpdateColumnLayout.MinActualWidth => CoerceActualWidth(0);
         double IUpdateColumnLayout.MaxActualWidth => CoerceActualWidth(double.PositiveInfinity);
         bool IUpdateColumnLayout.StarWidthWasConstrained => _starWidthWasConstrained;
@@ -149,18 +141,18 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
         private double CoerceActualWidth(double width)
         {
-            width = _minWidth?.GridUnitType switch
+            width = Options.MinWidth.GridUnitType switch
             {
                 GridUnitType.Auto => Math.Max(width, _autoWidth),
-                GridUnitType.Pixel => Math.Max(width, _minWidth.Value.Value),
+                GridUnitType.Pixel => Math.Max(width, Options.MinWidth.Value),
                 GridUnitType.Star => throw new NotImplementedException(),
                 _ => width
             };
 
-            return _maxWidth?.GridUnitType switch
+            return Options.MaxWidth?.GridUnitType switch
             {
                 GridUnitType.Auto => Math.Min(width, _autoWidth),
-                GridUnitType.Pixel => Math.Min(width, _maxWidth.Value.Value),
+                GridUnitType.Pixel => Math.Min(width, Options.MaxWidth.Value.Value),
                 GridUnitType.Star => throw new NotImplementedException(),
                 _ => width
             };

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`2.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`2.cs
@@ -40,7 +40,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             Expression<Func<TModel, TValue?>> getter,
             Action<TModel, TValue?>? setter,
             GridLength? width,
-            ColumnOptions<TModel>? options)
+            ColumnOptions<TModel> options)
             : base(header, width, options)
         {
             ValueSelector = getter.Compile();
@@ -73,7 +73,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             TypedBinding<TModel, TValue?> binding,
             GridLength? width,
             ColumnOptions<TModel>? options)
-            : base(header, width, options)
+            : base(header, width, options ?? new())
         {
             ValueSelector = valueSelector;
             Binding = binding;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ExpanderCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ExpanderCell.cs
@@ -39,6 +39,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public bool CanEdit => _inner.CanEdit;
         public ICell Content => _inner;
         public IExpanderRow<TModel> Row { get; }
+        public bool SingleTapEdit => _inner.SingleTapEdit;
         public bool ShowExpander => Row.ShowExpander;
         public object? Value => _inner.Value;
 

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ISearchableTextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ISearchableTextColumn.cs
@@ -2,7 +2,7 @@
 {
     public interface ITextSearchableColumn<TModel>
     {
-        public bool IsTextSearchEnabled { get; set; }
+        public bool IsTextSearchEnabled { get; }
         internal string? SelectValue(TModel model);
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCell.cs
@@ -9,6 +9,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     public interface ITextCell : ICell
     {
         /// <summary>
+        /// Gets or sets the cell's value as a string.
+        /// </summary>
+        string? Text { get; set; }
+
+        /// <summary>
         /// Gets the cell's text trimming mode.
         /// </summary>
         TextTrimming TextTrimming { get; }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCellOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCellOptions.cs
@@ -1,17 +1,9 @@
-﻿using System;
+﻿using Avalonia.Media;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
-    /// <summary>
-    /// Represents a cell in an <see cref="ITreeDataGridSource"/>.
-    /// </summary>
-    public interface ICell
+    public interface ITextCellOptions
     {
-        /// <summary>
-        /// Gets a value indicating whether the cell can enter edit mode.
-        /// </summary>
-        bool CanEdit { get; }
-
         /// <summary>
         /// Gets a value indicating whether a single tap will begin edit mode on a cell.
         /// </summary>
@@ -21,8 +13,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         bool SingleTapEdit { get; }
 
         /// <summary>
-        /// Gets the value of the cell.
+        /// Gets the text trimming mode for the cell.
         /// </summary>
-        object? Value { get; }
+        TextTrimming TextTrimming { get; }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateCell.cs
@@ -13,6 +13,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         }
 
         public bool CanEdit => false;
+        public bool SingleTapEdit => false;
         public Func<Control, IDataTemplate> GetCellTemplate { get; }
         public object? Value { get; }
     }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumn.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             IDataTemplate cellTemplate,
             GridLength? width = null,
             ColumnOptions<TModel>? options = null)
-            : base(header, width, options)
+            : base(header, width, options ?? new())
         {
             _sortAscending = options?.CompareAscending;
             _sortDescending = options?.CompareDescending;
@@ -37,7 +37,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             object cellTemplateResourceKey,
             GridLength? width = null,
             ColumnOptions<TModel>? options = null)
-            : base(header, width, options)
+            : base(header, width, options ?? new())
         {
             _sortAscending = options?.CompareAscending;
             _sortDescending = options?.CompareDescending;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumn.cs
@@ -13,8 +13,6 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// <typeparam name="TValue">The column data type.</typeparam>
     public class TemplateColumn<TModel> : ColumnBase<TModel>, ITextSearchableColumn<TModel>
     {
-        private readonly Comparison<TModel?>? _sortAscending;
-        private readonly Comparison<TModel?>? _sortDescending;
         private readonly Func<Control, IDataTemplate> _getCellTemplate;
         private IDataTemplate? _cellTemplate;
         private object? _cellTemplateResourceKey;
@@ -23,11 +21,9 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             object? header,
             IDataTemplate cellTemplate,
             GridLength? width = null,
-            ColumnOptions<TModel>? options = null)
+            TemplateColumnOptions<TModel>? options = null)
             : base(header, width, options ?? new())
         {
-            _sortAscending = options?.CompareAscending;
-            _sortDescending = options?.CompareDescending;
             _getCellTemplate = GetCellTemplate;
             _cellTemplate = cellTemplate;
         }
@@ -36,19 +32,17 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             object? header,
             object cellTemplateResourceKey,
             GridLength? width = null,
-            ColumnOptions<TModel>? options = null)
+            TemplateColumnOptions<TModel>? options = null)
             : base(header, width, options ?? new())
         {
-            _sortAscending = options?.CompareAscending;
-            _sortDescending = options?.CompareDescending;
             _getCellTemplate = GetCellTemplate;
             _cellTemplateResourceKey = cellTemplateResourceKey ??
                 throw new ArgumentNullException(nameof(cellTemplateResourceKey));
         }
 
-        public Func<TModel, string?>? TextSearchValueSelector { get; set; }
-        public bool IsTextSearchEnabled { get; set; }
+        public new TemplateColumnOptions<TModel> Options => (TemplateColumnOptions<TModel>)base.Options;
 
+        bool ITextSearchableColumn<TModel>.IsTextSearchEnabled => Options.IsTextSearchEnabled;
 
         /// <summary>
         /// Gets the template to use to display the contents of a cell that is not in editing mode.
@@ -79,12 +73,12 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         {
             return direction switch
             {
-                ListSortDirection.Ascending => _sortAscending,
-                ListSortDirection.Descending => _sortDescending,
+                ListSortDirection.Ascending => Options.CompareAscending,
+                ListSortDirection.Descending => Options.CompareDescending,
                 _ => null,
             };
         }
 
-        string? ITextSearchableColumn<TModel>.SelectValue(TModel model) => TextSearchValueSelector?.Invoke(model);
+        string? ITextSearchableColumn<TModel>.SelectValue(TModel model) => Options.TextSearchValueSelector?.Invoke(model);
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumnOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TemplateColumnOptions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Avalonia.Media;
+
+namespace Avalonia.Controls.Models.TreeDataGrid
+{
+    /// <summary>
+    /// Holds less commonly-used options for a <see cref="TemplateColumn{TModel}"/>.
+    /// </summary>
+    /// <typeparam name="TModel">The model type.</typeparam>
+    public class TemplateColumnOptions<TModel> : ColumnOptions<TModel>
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the column takes part in text searches.
+        /// </summary>
+        public bool IsTextSearchEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a function which selects the search text from a model.
+        /// </summary>
+        public Func<TModel, string?>? TextSearchValueSelector { get; set; }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
@@ -16,12 +16,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         [AllowNull] private T? _cancelValue;
         private bool _isEditing;
 
-#pragma warning disable CS8618
         public TextCell(T? value)
-#pragma warning restore CS8618
         {
             _value = value;
             IsReadOnly = true;
+            TextTrimming = TextTrimming.None;
         }
 
         public TextCell(
@@ -43,6 +42,12 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public bool CanEdit => !IsReadOnly;
         public bool IsReadOnly { get; }
         public TextTrimming TextTrimming { get; }
+
+        public string? Text
+        {
+            get => _value?.ToString();
+            set => Value = (T?)Convert.ChangeType(value, typeof(T));
+        }
 
         public T? Value
         {

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
@@ -26,11 +26,12 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public TextCell(
             ISubject<BindingValue<T>> binding,
             bool isReadOnly,
-            TextTrimming textTrimming)
+            ITextCellOptions? options = null)
         {
             _binding = binding;
             IsReadOnly = isReadOnly;
-            TextTrimming = textTrimming;
+            TextTrimming = options?.TextTrimming ?? TextTrimming.None;
+            SingleTapEdit = options?.SingleTapEdit ?? false;
 
             _subscription = binding.Subscribe(x =>
             {
@@ -41,6 +42,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
         public bool CanEdit => !IsReadOnly;
         public bool IsReadOnly { get; }
+        public bool SingleTapEdit { get; }
         public TextTrimming TextTrimming { get; }
 
         public string? Text

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq.Expressions;
-using Avalonia.Media;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
@@ -12,8 +11,6 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     public class TextColumn<TModel, TValue> : ColumnBase<TModel, TValue>, ITextSearchableColumn<TModel>
         where TModel : class
     {
-        private readonly ITextCellOptions? _cellOptions;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TextColumn{TModel, TValue}"/> class.
         /// </summary>
@@ -30,9 +27,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             Expression<Func<TModel, TValue?>> getter,
             GridLength? width = null,
             TextColumnOptions<TModel>? options = null)
-            : base(header, getter, null, width, options)
+            : base(header, getter, null, width, options ?? new())
         {
-            _cellOptions = options;
         }
 
         /// <summary>
@@ -56,16 +52,17 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             Action<TModel, TValue?> setter,
             GridLength? width = null,
             TextColumnOptions<TModel>? options = null)
-            : base(header, getter, setter, width, options)
+            : base(header, getter, setter, width, options ?? new())
         {
-            _cellOptions = options;
         }
 
-        public bool IsTextSearchEnabled { get; set; }
+        public new TextColumnOptions<TModel> Options => (TextColumnOptions<TModel>)base.Options;
+
+        bool ITextSearchableColumn<TModel>.IsTextSearchEnabled => Options?.IsTextSearchEnabled ?? false;
 
         public override ICell CreateCell(IRow<TModel> row)
         {
-            return new TextCell<TValue?>(CreateBindingExpression(row.Model), Binding.Write is null, _cellOptions);
+            return new TextCell<TValue?>(CreateBindingExpression(row.Model), Binding.Write is null, Options);
         }
 
         string? ITextSearchableColumn<TModel>.SelectValue(TModel model)

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
@@ -12,7 +12,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     public class TextColumn<TModel, TValue> : ColumnBase<TModel, TValue>, ITextSearchableColumn<TModel>
         where TModel : class
     {
-        private readonly TextTrimming _textTrimming;
+        private readonly ITextCellOptions? _cellOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextColumn{TModel, TValue}"/> class.
@@ -32,7 +32,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             TextColumnOptions<TModel>? options = null)
             : base(header, getter, null, width, options)
         {
-            _textTrimming = options?.TextTrimming ?? TextTrimming.CharacterEllipsis;
+            _cellOptions = options;
         }
 
         /// <summary>
@@ -58,14 +58,14 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             TextColumnOptions<TModel>? options = null)
             : base(header, getter, setter, width, options)
         {
-            _textTrimming = options?.TextTrimming ?? TextTrimming.CharacterEllipsis;
+            _cellOptions = options;
         }
 
         public bool IsTextSearchEnabled { get; set; }
 
         public override ICell CreateCell(IRow<TModel> row)
         {
-            return new TextCell<TValue?>(CreateBindingExpression(row.Model), Binding.Write is null, _textTrimming);
+            return new TextCell<TValue?>(CreateBindingExpression(row.Model), Binding.Write is null, _cellOptions);
         }
 
         string? ITextSearchableColumn<TModel>.SelectValue(TModel model)

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
@@ -9,6 +9,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     public class TextColumnOptions<TModel> : ColumnOptions<TModel>, ITextCellOptions
     {
         /// <summary>
+        /// Gets or sets a value indicating whether the column takes part in text searches.
+        /// </summary>
+        public bool IsTextSearchEnabled { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether a single tap will begin edit mode
         /// on a cell.
         /// </summary>

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
@@ -6,8 +6,17 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// Holds less commonly-used options for a <see cref="TextColumn{TModel, TValue}"/>.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public class TextColumnOptions<TModel> : ColumnOptions<TModel>
+    public class TextColumnOptions<TModel> : ColumnOptions<TModel>, ITextCellOptions
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether a single tap will begin edit mode
+        /// on a cell.
+        /// </summary>
+        /// <remarks>
+        /// If false, a double-tap is required to enter edit mode.
+        /// </remarks>
+        public bool SingleTapEdit { get; set; }
+
         /// <summary>
         /// Gets or sets the text trimming mode for the cells in the column.
         /// </summary>

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/ITreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/ITreeDataGridCell.cs
@@ -2,7 +2,7 @@
 
 namespace Avalonia.Controls.Primitives
 {
-    internal interface ITreeDataGridCell :  ISelectable
+    internal interface ITreeDataGridCell
     {
         int ColumnIndex { get; }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -23,6 +23,7 @@ namespace Avalonia.Controls.Primitives
         static TreeDataGridCell()
         {
             FocusableProperty.OverrideDefaultValue<TreeDataGridCell>(true);
+            DoubleTappedEvent.AddClassHandler<TreeDataGridCell>((x, e) => x.OnDoubleTapped(e));
         }
 
         public int ColumnIndex { get; private set; } = -1;
@@ -104,6 +105,15 @@ namespace Avalonia.Controls.Primitives
             result = result.Inflate(new Thickness(1, 0));
 
             return result;
+        }
+
+        protected virtual void OnDoubleTapped(TappedEventArgs e)
+        {
+            if (!_isEditing && CanEdit && !e.Handled)
+            {
+                BeginEdit();
+                e.Handled = true;
+            }
         }
 
         protected override void OnKeyDown(KeyEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -7,17 +7,10 @@ using Avalonia.LogicalTree;
 
 namespace Avalonia.Controls.Primitives
 {
-    [PseudoClasses(":selected", ":editing")]
+    [PseudoClasses(":editing")]
     public abstract class TreeDataGridCell : TemplatedControl, ITreeDataGridCell
     {
-        public static readonly DirectProperty<TreeDataGridCell, bool> IsSelectedProperty =
-            AvaloniaProperty.RegisterDirect<TreeDataGridCell, bool>(
-                nameof(IsSelected),
-                o => o.IsSelected,
-                (o, v) => o.IsSelected = v);
-
         private bool _isEditing;
-        private bool _isSelected;
         private TreeDataGrid? _treeDataGrid;
 
         static TreeDataGridCell()
@@ -29,12 +22,6 @@ namespace Avalonia.Controls.Primitives
         public int ColumnIndex { get; private set; } = -1;
         public int RowIndex { get; private set; } = -1;
         public ICell? Model { get; private set; }
-
-        public bool IsSelected
-        {
-            get => _isSelected;
-            set => SetAndRaise(IsSelectedProperty, ref _isSelected, value);
-        }
 
         public virtual void Realize(TreeDataGridElementFactory factory, ICell model, int columnIndex, int rowIndex)
         {
@@ -141,25 +128,6 @@ namespace Avalonia.Controls.Primitives
 
         protected virtual void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
-        }
-
-        protected override void OnPointerPressed(PointerPressedEventArgs e)
-        {
-            base.OnPointerPressed(e);
-
-            if (!_isEditing && CanEdit && !e.Handled && IsSelected)
-            {
-                BeginEdit();
-                e.Handled = true;
-            }
-        }
-
-        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
-        {
-            if (change.Property == IsSelectedProperty)
-            {
-                PseudoClasses.Set(":selected", change.GetNewValue<bool>());
-            }
         }
 
         private bool EndEditCore()

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -12,6 +12,7 @@ namespace Avalonia.Controls.Primitives
     {
         private bool _isEditing;
         private TreeDataGrid? _treeDataGrid;
+        private Point _pressedPoint;
 
         static TreeDataGridCell()
         {
@@ -106,9 +107,18 @@ namespace Avalonia.Controls.Primitives
             return result;
         }
 
+        protected virtual void OnTapped(TappedEventArgs e)
+        {
+            if (!_isEditing && CanEdit && Model?.SingleTapEdit == true && !e.Handled)
+            {
+                BeginEdit();
+                e.Handled = true;
+            }
+        }
+
         protected virtual void OnDoubleTapped(TappedEventArgs e)
         {
-            if (!_isEditing && CanEdit && !e.Handled)
+            if (!_isEditing && CanEdit && Model?.SingleTapEdit != true && !e.Handled)
             {
                 BeginEdit();
                 e.Handled = true;
@@ -128,6 +138,33 @@ namespace Avalonia.Controls.Primitives
 
         protected virtual void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
+        }
+
+        protected override void OnPointerPressed(PointerPressedEventArgs e)
+        {
+            base.OnPointerPressed(e);
+
+            if (!_isEditing && CanEdit && Model?.SingleTapEdit == true && !e.Handled)
+            {
+                _pressedPoint = e.GetCurrentPoint(this).Position;
+                e.Handled = true;
+            }
+        }
+
+        protected override void OnPointerReleased(PointerReleasedEventArgs e)
+        {
+            base.OnPointerReleased(e);
+
+            if (!_isEditing && CanEdit && Model?.SingleTapEdit == true && !e.Handled)
+            {
+                var point = e.GetCurrentPoint(this).Position;
+
+                if (new Rect(Bounds.Size).ContainsExclusive(point))
+                {
+                    BeginEdit();
+                    e.Handled = true;
+                }
+            }
         }
 
         private bool EndEditCore()

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -62,21 +62,33 @@ namespace Avalonia.Controls.Primitives
             if (!_isEditing)
             {
                 _isEditing = true;
-                (DataContext as IEditableObject)?.BeginEdit();
+                (Model as IEditableObject)?.BeginEdit();
                 PseudoClasses.Add(":editing");
             }
         }
 
         protected void CancelEdit()
         {
-            if (EndEditCore())
-                (DataContext as IEditableObject)?.CancelEdit();
+            if (EndEditCore() && Model is IEditableObject editable)
+                editable.CancelEdit();
         }
 
         protected void EndEdit()
         {
-            if (EndEditCore())
-                (DataContext as IEditableObject)?.EndEdit();
+            if (EndEditCore() && Model is IEditableObject editable)
+                editable.EndEdit();
+        }
+
+        protected void SubscribeToModelChanges()
+        {
+            if (Model is INotifyPropertyChanged inpc)
+                inpc.PropertyChanged += OnModelPropertyChanged;
+        }
+
+        protected void UnsubscribeFromModelChanges()
+        {
+            if (Model is INotifyPropertyChanged inpc)
+                inpc.PropertyChanged -= OnModelPropertyChanged;
         }
 
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
@@ -125,6 +137,10 @@ namespace Avalonia.Controls.Primitives
                 BeginEdit();
                 e.Handled = true;
             }
+        }
+
+        protected virtual void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
         }
 
         protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.Models.TreeDataGrid;
+﻿using System.ComponentModel;
+using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
@@ -32,7 +33,11 @@ namespace Avalonia.Controls.Primitives
         public string? Value
         {
             get => _value;
-            set => SetAndRaise(ValueProperty, ref _value, value);
+            set
+            {
+                if (SetAndRaise(ValueProperty, ref _value, value) && Model is ITextCell cell)
+                    cell.Text = _value;
+            }
         }
 
         protected override bool CanEdit => _canEdit;
@@ -43,6 +48,13 @@ namespace Avalonia.Controls.Primitives
             Value = model.Value?.ToString();
             TextTrimming = (model as ITextCell)?.TextTrimming ?? TextTrimming.CharacterEllipsis;
             base.Realize(factory, model, columnIndex, rowIndex);
+            SubscribeToModelChanges();
+        }
+
+        public override void Unrealize()
+        {
+            UnsubscribeFromModelChanges();
+            base.Unrealize();
         }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -64,6 +76,14 @@ namespace Avalonia.Controls.Primitives
                 _edit.KeyDown += EditKeyDown;
                 _edit.LostFocus += EditLostFocus;
             }
+        }
+
+        protected override void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            base.OnModelPropertyChanged(sender, e);
+
+            if (e.PropertyName == nameof(ITextCell.Value))
+                Value = Model?.Value?.ToString();
         }
 
         private void EditKeyDown(object? sender, KeyEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml
@@ -14,8 +14,4 @@
     <Setter Property="MinHeight" Value="25"/>
   </Style>
   
-  <Style Selector=":is(TreeDataGridCell):selected">
-    <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}"/>
-  </Style>
-
 </Styles>

--- a/src/Avalonia.Controls.TreeDataGrid/Themes/FluentControls.axaml
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/FluentControls.axaml
@@ -223,7 +223,7 @@
                   CornerRadius="{TemplateBinding CornerRadius}"
                   Padding="{TemplateBinding Padding}">
             <TextBox Name="PART_Edit"
-                     Text="{Binding Value, RelativeSource={RelativeSource TemplatedParent}}" />
+                     Text="{TemplateBinding Value, Mode=TwoWay}" />
           </Border>
         </ControlTemplate>
       </Setter>

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Value_Is_Initially_Read_From_String()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, true, TextTrimming.None);
+            var target = new TextCell<string>(binding, true);
 
             Assert.Equal("initial", target.Text);
             Assert.Equal("initial", target.Value);
@@ -27,7 +27,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Modified_Value_Is_Written_To_Binding()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, false, TextTrimming.None);
+            var target = new TextCell<string>(binding, false);
             var result = new List<string>();
 
             binding.Subscribe(x => result.Add(x.Value));
@@ -40,7 +40,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Modified_Text_Is_Written_To_Binding()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, false, TextTrimming.None);
+            var target = new TextCell<string>(binding, false);
             var result = new List<string>();
 
             binding.Subscribe(x => result.Add(x.Value));
@@ -53,7 +53,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Modified_Value_Is_Written_To_Binding_On_EndEdit()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, false, TextTrimming.None);
+            var target = new TextCell<string>(binding, false);
             var result = new List<string>();
 
             binding.Subscribe(x => result.Add(x.Value));
@@ -76,7 +76,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Modified_Value_Is_Not_Written_To_Binding_On_CancelEdit()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, false, TextTrimming.None);
+            var target = new TextCell<string>(binding, false);
             var result = new List<string>();
 
             binding.Subscribe(x => result.Add(x.Value));

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Data;
+using Avalonia.Media;
+using Xunit;
+
+namespace Avalonia.Controls.TreeDataGridTests.Models
+{
+    public class TextCellTests
+    {
+        [Fact]
+        public void Value_Is_Initially_Read_From_String()
+        {
+            var binding = new BehaviorSubject<BindingValue<string>>("initial");
+            var target = new TextCell<string>(binding, true, TextTrimming.None);
+
+            Assert.Equal("initial", target.Text);
+            Assert.Equal("initial", target.Value);
+        }
+
+        [Fact]
+        public void Modified_Value_Is_Written_To_Binding()
+        {
+            var binding = new BehaviorSubject<BindingValue<string>>("initial");
+            var target = new TextCell<string>(binding, false, TextTrimming.None);
+            var result = new List<string>();
+
+            binding.Subscribe(x => result.Add(x.Value));
+            target.Value = "new";
+
+            Assert.Equal(new[] { "initial", "new" }, result);
+        }
+
+        [Fact]
+        public void Modified_Text_Is_Written_To_Binding()
+        {
+            var binding = new BehaviorSubject<BindingValue<string>>("initial");
+            var target = new TextCell<string>(binding, false, TextTrimming.None);
+            var result = new List<string>();
+
+            binding.Subscribe(x => result.Add(x.Value));
+            target.Text = "new";
+
+            Assert.Equal(new[] { "initial", "new" }, result);
+        }
+
+        [Fact]
+        public void Modified_Value_Is_Written_To_Binding_On_EndEdit()
+        {
+            var binding = new BehaviorSubject<BindingValue<string>>("initial");
+            var target = new TextCell<string>(binding, false, TextTrimming.None);
+            var result = new List<string>();
+
+            binding.Subscribe(x => result.Add(x.Value));
+
+            target.BeginEdit();
+            target.Text = "new";
+
+            Assert.Equal("new", target.Text);
+            Assert.Equal("new", target.Value);
+            Assert.Equal(new[] { "initial"}, result);
+
+            target.EndEdit();
+
+            Assert.Equal("new", target.Text);
+            Assert.Equal("new", target.Value);
+            Assert.Equal(new[] { "initial", "new" }, result);
+        }
+
+        [Fact]
+        public void Modified_Value_Is_Not_Written_To_Binding_On_CancelEdit()
+        {
+            var binding = new BehaviorSubject<BindingValue<string>>("initial");
+            var target = new TextCell<string>(binding, false, TextTrimming.None);
+            var result = new List<string>();
+
+            binding.Subscribe(x => result.Add(x.Value));
+
+            target.BeginEdit();
+            target.Text = "new";
+
+            Assert.Equal("new", target.Text);
+            Assert.Equal("new", target.Value);
+            Assert.Equal(new[] { "initial" }, result);
+
+            target.CancelEdit();
+
+            Assert.Equal("initial", target.Text);
+            Assert.Equal("initial", target.Value);
+            Assert.Equal(new[] { "initial" }, result);
+        }
+    }
+}


### PR DESCRIPTION
Some options were set on the columns themselves and some in the options. This PR is trying to make this more consistent by moving the following properties to the options classes:

- `ColumnBase.CanUserResize`
- `TemplateColumn`/`TextColumn.IsTextSearchEnabled`
- `TemplateColumn.TextSearchValueSelector`

Also adds `CheckBoxColumnOptions` - currently empty, but future-protects the API.

Depends on #162 