### PR TITLE
Drag adorner fixes.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -122,7 +122,7 @@ namespace Avalonia.Controls.Primitives
 
             if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed || 
                 e.Handled ||
-                delta.X < DragDistance && delta.Y < DragDistance ||
+                Math.Abs(delta.X) < DragDistance && Math.Abs(delta.Y) < DragDistance ||
                 _mouseDownPosition == s_InvalidPoint)
                 return;
 

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Avalonia.Controls.Documents;
@@ -8,10 +7,8 @@ using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Selection;
 using Avalonia.Controls.Shapes;
-using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.Utilities;
 using Avalonia.VisualTree;
@@ -95,6 +92,7 @@ namespace Avalonia.Controls
         private ListSortDirection _userSortDirection;
         private TreeDataGridCellEventArgs? _cellArgs;
         private Canvas? _dragAdorner;
+        private bool _hideDragAdorner;
         private DispatcherTimer? _autoScrollTimer;
         private bool _autoScrollDirection;
 
@@ -448,6 +446,8 @@ namespace Avalonia.Controls
 
         private Canvas? GetOrCreateDragAdorner()
         {
+            _hideDragAdorner = false;
+
             if (_dragAdorner is not null)
                 return _dragAdorner;
 
@@ -512,13 +512,16 @@ namespace Avalonia.Controls
 
         private void HideDragAdorner()
         {
-            if (_dragAdorner is null)
-                return;
+            _hideDragAdorner = true;
 
-            if (_dragAdorner.Parent is AdornerLayer layer)
-                layer.Children.Remove(_dragAdorner);
-
-            _dragAdorner = null;
+            DispatcherTimer.RunOnce(() =>
+            {
+                if (_hideDragAdorner && _dragAdorner?.Parent is AdornerLayer layer)
+                {
+                    layer.Children.Remove(_dragAdorner);
+                    _dragAdorner = null;
+                }
+            }, TimeSpan.FromMilliseconds(50));
         }
 
         private void StopDrag()

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -3,9 +3,11 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Avalonia.Controls.Documents;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Selection;
+using Avalonia.Controls.Shapes;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -92,7 +94,7 @@ namespace Avalonia.Controls
         private Control? _userSortColumn;
         private ListSortDirection _userSortDirection;
         private TreeDataGridCellEventArgs? _cellArgs;
-        private Border? _dragAdorner;
+        private Canvas? _dragAdorner;
         private DispatcherTimer? _autoScrollTimer;
         private bool _autoScrollDirection;
 
@@ -444,7 +446,7 @@ namespace Avalonia.Controls
             }
         }
 
-        private Border? GetOrCreateDragAdorner()
+        private Canvas? GetOrCreateDragAdorner()
         {
             if (_dragAdorner is not null)
                 return _dragAdorner;
@@ -454,22 +456,28 @@ namespace Avalonia.Controls
             if (adornerLayer is null)
                 return null;
 
-            _dragAdorner ??= new Border
+            _dragAdorner ??= new Canvas
             {
-                BorderBrush = Brushes.Black,
-                BorderThickness = new Thickness(2),
+                Children =
+                {
+                    new Rectangle
+                    {
+                        Stroke = TextElement.GetForeground(this),
+                        StrokeThickness = 2,
+                    },
+                },
                 IsHitTestVisible = false,
-                Margin = new Thickness(0, -1),
             };
 
             adornerLayer.Children.Add(_dragAdorner);
-            AdornerLayer.SetIsClipEnabled(_dragAdorner, false);
+            AdornerLayer.SetAdornedElement(_dragAdorner, this);
             return _dragAdorner;
         }
 
         private void ShowDragAdorner(TreeDataGridRow row, TreeDataGridRowDropPosition position)
         {
-            if (position == TreeDataGridRowDropPosition.None)
+            if (position == TreeDataGridRowDropPosition.None ||
+                row.TransformToVisual(this) is not { } transform)
             {
                 HideDragAdorner();
                 return;
@@ -479,18 +487,25 @@ namespace Avalonia.Controls
             if (adorner is null)
                 return;
 
-            AdornerLayer.SetAdornedElement(adorner, row);
+            var rectangle = (Rectangle)adorner.Children[0];
+            var rowBounds = new Rect(row.Bounds.Size).TransformToAABB(transform);
+
+            Canvas.SetLeft(rectangle, rowBounds.Left);
+            rectangle.Width = rowBounds.Width;
 
             switch (position)
             {
                 case TreeDataGridRowDropPosition.Before:
-                    adorner.BorderThickness = new(0, 2, 0, 0);
+                    Canvas.SetTop(rectangle, rowBounds.Top);
+                    rectangle.Height = 0;
                     break;
                 case TreeDataGridRowDropPosition.After:
-                    adorner.BorderThickness = new(0, 0, 0, 2);
+                    Canvas.SetTop(rectangle, rowBounds.Bottom);
+                    rectangle.Height = 0;
                     break;
                 case TreeDataGridRowDropPosition.Inside:
-                    adorner.BorderThickness = new(2);
+                    Canvas.SetTop(rectangle, rowBounds.Top);
+                    rectangle.Height = rowBounds.Height;
                     break;
             }
         }
@@ -604,7 +619,10 @@ namespace Avalonia.Controls
             }
         }
 
-        private void OnDragLeave(RoutedEventArgs e) => StopDrag();
+        private void OnDragLeave(RoutedEventArgs e)
+        {
+            StopDrag();
+        }
 
         private void OnDrop(DragEventArgs e)
         {


### PR DESCRIPTION
- Drag adorner was sometimes not showing for a row. I couldn't get this to happen in a reproducible manner on my machine, but there seems to be a problem with Adorners on Avalonia 11 (maybe https://github.com/AvaloniaUI/Avalonia/issues/10701?). This PR tries a different approach and adorns the `TreeDataGrid` itself instead of the `TreeDatGridRow` which _seems_ to be better
- Hide drag adorner after a delay: The `DragLeave` event gets fired before the `DragEnter` event for the new control, which caused flickering. Might be an Avalonia bug, though it also looks like [WPF has this behavior](https://stackoverflow.com/a/5447860) so maybe not. Hide the drag adorner after a small delay to work around this.