### PR TITLE
Fix some drag/drop issues

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
@@ -211,7 +211,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
             private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
             {
-                _owner._controller.OnChildCollectionChanged(_owner, e);
+                if (_owner.IsExpanded)
+                    _owner._controller.OnChildCollectionChanged(_owner, e);
             }
         }
     }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
@@ -94,6 +94,27 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public void UpdateModelIndex(int delta)
         {
             ModelIndexPath = ModelIndexPath[..^1].Append(ModelIndexPath[^1] + delta);
+
+            if (_childRows is null)
+                return;
+
+            var childCount = _childRows.Count;
+
+            for (var i = 0; i < childCount; ++i)
+                _childRows[i].UpdateParentModelIndex(ModelIndexPath);
+        }
+
+        public void UpdateParentModelIndex(IndexPath parentIndex)
+        {
+            ModelIndexPath = parentIndex.Append(ModelIndex);
+
+            if (_childRows is null)
+                return;
+
+            var childCount = _childRows.Count;
+
+            for (var i = 0; i < childCount; ++i)
+                _childRows[i].UpdateParentModelIndex(ModelIndexPath);
         }
 
         void IExpanderRow<TModel>.UpdateShowExpander(IExpanderCell cell, bool value)

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -141,6 +141,27 @@ namespace Avalonia.Controls.TreeDataGridTests
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            public void Supports_Removing_Root_Row_With_Later_Row_Expanded(bool sorted)
+            {
+                var data = CreateData();
+
+                var target = CreateTarget(data, sorted);
+
+                target.Expand(new IndexPath(4));
+
+                Assert.Equal(10, target.Rows.Count);
+
+                var raised = 0;
+                target.Rows.CollectionChanged += (s, e) => ++raised;
+
+                data.RemoveAt(1);
+
+                AssertState(target, data, 9, sorted, new IndexPath(3));
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
             public void Removing_Expanded_Root_Row_Unsubscribes_From_CollectionChanged(bool sorted)
             {
                 var data = CreateData();

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -216,6 +216,22 @@ namespace Avalonia.Controls.TreeDataGridTests
             [Theory]
             [InlineData(false)]
             [InlineData(true)]
+            public void Supports_Adding_Child_To_Expanded_Then_Unexpanded_Root_Node(bool sorted)
+            {
+                var data = CreateData();
+                var target = CreateTarget(data, sorted);
+
+                target.Expand(new IndexPath(0));
+                target.Collapse(new IndexPath(0));
+
+                data[0].Children!.Add(new Node { Id = 100, Caption = "New Node 1" });
+
+                AssertState(target, data, 5, sorted);
+            }
+
+            [Theory]
+            [InlineData(false)]
+            [InlineData(true)]
             public void Supports_Inserting_Child_Row(bool sorted)
             {
                 var data = CreateData();


### PR DESCRIPTION
This PR fixes two issues that show up commonly when using drag/drop (although strictly speaking they're not actually drag/drop problems - they're problems at the hierarchical model layer):

- When dropping nodes into a later child node, the rows could become unselectable: we weren't updating child model indexes correctly. When a parent model index changes, it needs to be propagated to its descendants.
- #143: Dropping into an expanded and then collapsed node threw an error: don't bubble up collection changed events for collapsed nodes to the controller.

