### PR TITLE
MVP of cell selection

### DIFF
--- a/docs/column-types.md
+++ b/docs/column-types.md
@@ -20,6 +20,24 @@ This is the signature of the `TextColumn` constructor. There are two most import
 **Note**:               
 The sample above is taken from [this article](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/blob/master/docs/get-started-flat.md). If you feel like you need more examples feel free to check it, there is a sample that shows how to use TextColumns and how to run a whole `TreeDataGrid` using them. 
 
+## CheckBoxColumn
+
+As its name suggests, `CheckBoxColumn` displays a `CheckBox` in its cells. For a readonly checkbox:
+
+```csharp
+new CheckColumn<Person>("Firstborn", x => x.IsFirstborn)
+```
+
+The first parameter defines the column header. The second parameter is an expression which gets the value of the property from the model.
+
+For a read/write checkbox:
+
+```csharp
+new CheckColumn<Person>("Firstborn", x => x.IsFirstborn, (o, v) => o.IsFirstborn = v)
+```
+
+This overload adds a second paramter which is the expression used to set the property in the model.
+
 ## HierarchicalExpanderColumn
 `HierarchicalExpanderColumn` can be used only with `HierarchicalTreeDataGrid` (a.k.a TreeView) thats what Hierarchical stands for in its name, also it can be used only with `HierarchicalTreeDataGridSource`. This type of columns can be useful when you want cells to show an expander to reveal nested data.
 

--- a/docs/selection.md
+++ b/docs/selection.md
@@ -1,0 +1,92 @@
+# Selection
+
+Two selection modes are supported:
+
+- Row selection allows the user to select whole rows
+- Cell selection allows the user to select individial cells
+
+Both selection types support either single or multiple selection. The default selection type is single row selection.
+
+## Index Paths
+
+Because `TreeDataGrid` supports hierarchical data, using a simple index to identify a row in the data source isn't enough. Instead indexes are represented using the `IndexPath` struct.
+
+An `IndexPath` is essentially an array of indexes, each element of which specifies the index at a succesively deeper level in the hierarchy of the data.
+
+Consider the following data source:
+
+```
+|- A
+|  |- B
+|  |- C
+|     |- D
+|- E
+```
+
+- `A` has an index path of `0` as it's the first item at the root of the hierarchy
+- `B` has an index path of `0,0` as it's the first child of the first item
+- `C` has an index path of `0,1` as it's the second child of the first item
+- `D` has an index path of `0,1,0` as it's the first child of `C`
+- `E` has an index path of `1` as it's the second item in the root
+
+`IndexPath` is an immutable struct which is constructed with an array of integers, e.g.: `new ItemPath(0, 1, 0)`. There is also an implicit conversion from `int` for when working with a flat data source.
+
+## Row Selection
+
+Row selection is the default and is exposed via the `RowSelection` property on the `FlatTreeDataGridSource<TModel>` and `HierarchicalTreeDataGridSource<TModel>` classes when enabled. Row selection is stored in an instance of the `TreeDataGridRowSelectionModel<TModel>` class.
+
+By default is single selection. To enable multiple selection set the the `SingleSelect` property to `false`, e.g.:
+
+```csharp
+Source = new FlatTreeDataGridSource<Person>(_people)
+{
+    Columns =
+    {
+        new TextColumn<Person, string>("First Name", x => x.FirstName),
+        new TextColumn<Person, string>("Last Name", x => x.LastName),
+        new TextColumn<Person, int>("Age", x => x.Age),
+    },
+};
+
+Source.RowSelection!.SingleSelect = false;
+```
+
+The properties on `ITreeDataGridRowSelectionModel<TModel>` can be used to manipulate the selection, e.g.:
+
+```csharp
+Source.RowSelection!.SelectedIndex = 1;
+```
+
+Or
+
+```csharp
+Source.RowSelection!.SelectedIndex = new IndexPath(0, 1);
+```
+
+## Cell Selection
+
+To enable cell selection for a `TreeDataGridSource`, assign an instance of `TreeDataGridCellSelectionModel<TModel>` to the source's `Selection` property:
+
+```csharp
+Source = new FlatTreeDataGridSource<Person>(_people)
+{
+    Columns =
+    {
+        new TextColumn<Person, string>("First Name", x => x.FirstName),
+        new TextColumn<Person, string>("Last Name", x => x.LastName),
+        new TextColumn<Person, int>("Age", x => x.Age),
+    },
+};
+
+Source.Selection = new TreeDataGridCellSelectionModel<Person>(Source);
+```
+
+Or for multiple cell selection:
+
+```csharp
+Source.Selection = new TreeDataGridCellSelectionModel<Person>(Source) { SingleSelect = false };
+```
+
+Cell selection is is exposed via the `CellSelection` property on the `FlatTreeDataGridSource<TModel>` and `HierarchicalTreeDataGridSource<TModel>` classes when enabled.
+
+The `CellIndex` struct indentifies an individual cell with by combination of an integer column index and an `IndexPath` row index.

--- a/readme.md
+++ b/readme.md
@@ -32,3 +32,4 @@ We accept issues and pull requests but we answer and review only pull requests a
 - [Creating a flat `TreeDataGrid`](docs/get-started-flat.md)
 - [Creating a hierarchical `TreeDataGrid`](docs/get-started-hierarchical.md)
 - [Supported column types](docs/column-types.md)
+- [Selection](docs/selection.md)

--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -11,7 +11,8 @@
     <TabItem Header="Countries">
       <DockPanel>
         <TextBlock Classes="realized-count" DockPanel.Dock="Bottom"/>
-        <StackPanel DockPanel.Dock="Right" Spacing="4">
+        <StackPanel DockPanel.Dock="Right" Spacing="4" Margin="4 0 0 0">
+          <CheckBox IsChecked="{Binding Countries.CellSelection}">Cell Selection</CheckBox>
           <Label Target="countryTextBox">_Country</Label>
           <TextBox Name="countryTextBox">Sealand</TextBox>
           <Label Target="regionTextBox">_Region</Label>
@@ -48,6 +49,11 @@
           <ComboBox ItemsSource="{Binding Files.Drives}"
                     SelectedItem="{Binding Files.SelectedDrive}"
                     DockPanel.Dock="Left"/>
+          <CheckBox IsChecked="{Binding Files.CellSelection}"
+                    Margin="4 0 0 0"
+                    DockPanel.Dock="Right">
+            Cell Selection
+          </CheckBox>
           <TextBox Text="{Binding Files.SelectedPath, Mode=OneWay}"
                    Margin="4 0 0 0"
                    VerticalContentAlignment="Center"

--- a/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
@@ -3,13 +3,15 @@ using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
+using ReactiveUI;
 using TreeDataGridDemo.Models;
 
 namespace TreeDataGridDemo.ViewModels
 {
-    internal class CountriesPageViewModel
+    internal class CountriesPageViewModel : ReactiveObject
     {
         private readonly ObservableCollection<Country> _data;
+        private bool _cellSelection;
 
         public CountriesPageViewModel()
         {
@@ -20,8 +22,8 @@ namespace TreeDataGridDemo.ViewModels
                 Columns =
                 {
                     new TextColumn<Country, string>("Country", x => x.Name, (r, v) => r.Name = v, new GridLength(6, GridUnitType.Star), new()
-                    { 
-                        IsTextSearchEnabled = true 
+                    {
+                        IsTextSearchEnabled = true
                     }),
                     new TextColumn<Country, string>("Region", x => x.Region, new GridLength(4, GridUnitType.Star)),
                     new TextColumn<Country, int>("Population", x => x.Population, new GridLength(3, GridUnitType.Star)),
@@ -33,6 +35,23 @@ namespace TreeDataGridDemo.ViewModels
                 }
             };
             Source.RowSelection!.SingleSelect = false;
+        }
+
+        public bool CellSelection
+        {
+            get => _cellSelection;
+            set
+            {
+                if (_cellSelection != value)
+                {
+                    _cellSelection = value;
+                    if (_cellSelection)
+                        Source.Selection = new TreeDataGridCellSelectionModel<Country>(Source) { SingleSelect = false };
+                    else
+                        Source.Selection = new TreeDataGridRowSelectionModel<Country>(Source) { SingleSelect = false };
+                    this.RaisePropertyChanged();
+                }
+            }
         }
 
         public FlatTreeDataGridSource<Country> Source { get; }

--- a/samples/TreeDataGridDemo/ViewModels/FilesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/FilesPageViewModel.cs
@@ -20,6 +20,7 @@ namespace TreeDataGridDemo.ViewModels
     public class FilesPageViewModel : ReactiveObject
     {
         private static IconConverter? s_iconConverter;
+        private bool _cellSelection;
         private FileTreeNodeModel? _root;
         private string _selectedDrive;
         private string? _selectedPath;
@@ -92,6 +93,23 @@ namespace TreeDataGridDemo.ViewModels
                     _root = new FileTreeNodeModel(_selectedDrive, isDirectory: true, isRoot: true);
                     Source.Items = new[] { _root };
                 });
+        }
+
+        public bool CellSelection
+        {
+            get => _cellSelection;
+            set
+            {
+                if (_cellSelection != value)
+                {
+                    _cellSelection = value;
+                    if (_cellSelection)
+                        Source.Selection = new TreeDataGridCellSelectionModel<FileTreeNodeModel>(Source) { SingleSelect = false };
+                    else
+                        Source.Selection = new TreeDataGridRowSelectionModel<FileTreeNodeModel>(Source) { SingleSelect = false };
+                    this.RaisePropertyChanged();
+                }
+            }
         }
 
         public IList<string> Drives { get; }

--- a/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
+++ b/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>True</IsPackable>
+    <LangVersion>10</LangVersion>
     <RootNamespace>Avalonia.Controls</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Avalonia.Controls.TreeDataGrid/CellIndex.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/CellIndex.cs
@@ -1,0 +1,13 @@
+﻿namespace Avalonia.Controls
+{
+    /// <summary>
+    /// Represents a cell in a <see cref="TreeDataGrid"/>.
+    /// </summary>
+    /// <param name="ColumnIndex">
+    /// The index of the cell in the <see cref="TreeDataGrid.Columns"/> collection.
+    /// </param>
+    /// <param name="RowIndex">
+    /// The hierarchical index of the row model in the data source.
+    /// </param>
+    public readonly record struct CellIndex(int ColumnIndex, IndexPath RowIndex);
+}

--- a/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using Avalonia.Controls.Models;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Input;
@@ -12,8 +13,10 @@ namespace Avalonia.Controls
     /// A data source for a <see cref="TreeDataGrid"/> which displays a flat grid.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public class FlatTreeDataGridSource<TModel> : ITreeDataGridSource<TModel>, IDisposable
-        where TModel: class
+    public class FlatTreeDataGridSource<TModel> : NotifyingBase,
+        ITreeDataGridSource<TModel>,
+        IDisposable
+            where TModel: class
     {
         private IEnumerable<TModel> _items;
         private TreeDataGridItemsSourceView<TModel> _itemsView;
@@ -45,6 +48,7 @@ namespace Avalonia.Controls
                     _rows?.SetItems(_itemsView);
                     if (_selection is object)
                         _selection.Source = value;
+                    RaisePropertyChanged();
                 }
             }
         }
@@ -59,10 +63,14 @@ namespace Avalonia.Controls
             }
             set
             {
-                if (_selection is object)
-                    throw new InvalidOperationException("Selection is already initialized.");
-                _selection = value;
-                _isSelectionSet = true;
+                if (_selection != value)
+                {
+                    if (value?.Source != _items)
+                        throw new InvalidOperationException("Selection source must be set to Items.");
+                    _selection = value;
+                    _isSelectionSet = true;
+                    RaisePropertyChanged();
+                }
             }
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/FlatTreeDataGridSource.cs
@@ -66,6 +66,7 @@ namespace Avalonia.Controls
             }
         }
 
+        public ITreeDataGridCellSelectionModel<TModel>? CellSelection => Selection as ITreeDataGridCellSelectionModel<TModel>;
         public ITreeDataGridRowSelectionModel<TModel>? RowSelection => Selection as ITreeDataGridRowSelectionModel<TModel>;
         public bool IsHierarchical => false;
         public bool IsSorted => _comparer is not null;

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -77,6 +77,7 @@ namespace Avalonia.Controls
             }
         }
 
+        public ITreeDataGridCellSelectionModel<TModel>? CellSelection => Selection as ITreeDataGridCellSelectionModel<TModel>;
         public ITreeDataGridRowSelectionModel<TModel>? RowSelection => Selection as ITreeDataGridRowSelectionModel<TModel>;
         public bool IsHierarchical => true;
         public bool IsSorted => _comparison is not null;

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Avalonia.Controls.Models;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Input;
@@ -15,7 +16,8 @@ namespace Avalonia.Controls
     /// row may have multiple columns.
     /// </summary>
     /// <typeparam name="TModel">The model type.</typeparam>
-    public class HierarchicalTreeDataGridSource<TModel> : ITreeDataGridSource<TModel>,
+    public class HierarchicalTreeDataGridSource<TModel> : NotifyingBase,
+        ITreeDataGridSource<TModel>,
         IDisposable,
         IExpanderRowController<TModel>
         where TModel: class
@@ -70,10 +72,14 @@ namespace Avalonia.Controls
             }
             set
             {
-                if (_selection is object)
-                    throw new InvalidOperationException("Selection is already initialized.");
-                _selection = value;
-                _isSelectionSet = true;
+                if (_selection != value)
+                {
+                    if (value?.Source != _items)
+                        throw new InvalidOperationException("Selection source must be set to Items.");
+                    _selection = value;
+                    _isSelectionSet = true;
+                    RaisePropertyChanged();
+                }
             }
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/ITreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/ITreeDataGridSource.cs
@@ -10,7 +10,7 @@ namespace Avalonia.Controls
     /// <summary>
     /// Represents a data source for a <see cref="TreeDataGrid"/> control.
     /// </summary>
-    public interface ITreeDataGridSource
+    public interface ITreeDataGridSource : INotifyPropertyChanged
     {
         /// <summary>
         /// Gets the columns to be displayed.

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/ITreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/ITreeDataGridCell.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Selection;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -6,7 +7,13 @@ namespace Avalonia.Controls.Primitives
     {
         int ColumnIndex { get; }
 
-        void Realize(TreeDataGridElementFactory factory, ICell model, int columnIndex, int rowIndex);
+        void Realize(
+            TreeDataGridElementFactory factory,
+            ITreeDataGridSelectionInteraction? selection,
+            ICell model,
+            int columnIndex,
+            int rowIndex);
+
         void Unrealize();
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -196,6 +196,8 @@ namespace Avalonia.Controls.Primitives
             base.OnPropertyChanged(change);
         }
 
+        public void UpdateRowIndex(int index) => RowIndex = index;
+
         internal void UpdateSelection(ITreeDataGridSelectionInteraction? selection)
         {
             IsSelected = selection?.IsCellSelected(ColumnIndex, RowIndex) ?? false;

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Selection;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
 
@@ -10,7 +11,13 @@ namespace Avalonia.Controls.Primitives
     [PseudoClasses(":editing")]
     public abstract class TreeDataGridCell : TemplatedControl, ITreeDataGridCell
     {
+        public static readonly DirectProperty<TreeDataGridCell, bool> IsSelectedProperty =
+            AvaloniaProperty.RegisterDirect<TreeDataGridCell, bool>(
+                nameof(IsSelected),
+                o => o.IsSelected);
+
         private bool _isEditing;
+        private bool _isSelected;
         private TreeDataGrid? _treeDataGrid;
         private Point _pressedPoint;
 
@@ -24,7 +31,18 @@ namespace Avalonia.Controls.Primitives
         public int RowIndex { get; private set; } = -1;
         public ICell? Model { get; private set; }
 
-        public virtual void Realize(TreeDataGridElementFactory factory, ICell model, int columnIndex, int rowIndex)
+        public bool IsSelected
+        {
+            get => _isSelected;
+            private set => SetAndRaise(IsSelectedProperty, ref _isSelected, value);
+        }
+
+        public virtual void Realize(
+            TreeDataGridElementFactory factory,
+            ITreeDataGridSelectionInteraction? selection,
+            ICell model,
+            int columnIndex,
+            int rowIndex)
         {
             if (columnIndex < 0)
                 throw new IndexOutOfRangeException("Invalid column index.");
@@ -32,6 +50,7 @@ namespace Avalonia.Controls.Primitives
             ColumnIndex = columnIndex;
             RowIndex = rowIndex;
             Model = model;
+            IsSelected = selection?.IsCellSelected(columnIndex, rowIndex) ?? false;
 
             _treeDataGrid?.RaiseCellPrepared(this, columnIndex, RowIndex);
         }
@@ -165,6 +184,21 @@ namespace Avalonia.Controls.Primitives
                     e.Handled = true;
                 }
             }
+        }
+
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            if (change.Property == IsSelectedProperty)
+            {
+                PseudoClasses.Set(":selected", IsSelected);
+            }
+
+            base.OnPropertyChanged(change);
+        }
+
+        internal void UpdateSelection(ITreeDataGridSelectionInteraction? selection)
+        {
+            IsSelected = selection?.IsCellSelected(ColumnIndex, RowIndex) ?? false;
         }
 
         private bool EndEditCore()

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Selection;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
 using Avalonia.Media;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -61,7 +63,7 @@ namespace Avalonia.Controls.Primitives
         {
             var model = _rows!.RealizeCell(column, index, RowIndex);
             var cell = (TreeDataGridCell)GetElementFromFactory(model, index, this);
-            cell.Realize(ElementFactory!, model, index, RowIndex);
+            cell.Realize(ElementFactory!, GetSelection(), model, index, RowIndex);
             return cell;
         }
 
@@ -76,7 +78,7 @@ namespace Avalonia.Controls.Primitives
             else if (cell.ColumnIndex == -1 && cell.RowIndex == -1)
             {
                 var model = _rows!.RealizeCell(column, index, RowIndex);
-                ((TreeDataGridCell)element).Realize(ElementFactory!, model, index, RowIndex);
+                ((TreeDataGridCell)element).Realize(ElementFactory!, GetSelection(), model, index, RowIndex);
                 ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, index));
             }
             else
@@ -104,6 +106,20 @@ namespace Avalonia.Controls.Primitives
 
             if (change.Property == BackgroundProperty)
                 InvalidateVisual();
+        }
+        
+        internal void UpdateSelection(ITreeDataGridSelectionInteraction? selection)
+        {
+            foreach (var element in RealizedElements)
+            {
+                if (element is TreeDataGridCell { RowIndex: >= 0, ColumnIndex: >= 0 } cell)
+                    cell.UpdateSelection(selection);
+            }
+        }
+
+        private ITreeDataGridSelectionInteraction? GetSelection()
+        {
+            return this.FindAncestorOfType<TreeDataGrid>()?.SelectionInteraction;
         }
 
         public int GetChildIndex(ILogical child)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Xml.Linq;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Layout;
@@ -51,6 +52,12 @@ namespace Avalonia.Controls.Primitives
             if (index < 0 || Rows is null || index >= Rows.Count)
                 throw new ArgumentOutOfRangeException(nameof(index));
             RowIndex = index;
+
+            foreach (var element in RealizedElements)
+            {
+                if (element is TreeDataGridCell { RowIndex: >= 0, ColumnIndex: >= 0 } cell)
+                    cell.UpdateRowIndex(index);
+            }
         }
 
         protected override Size MeasureElement(int index, Control element, Size availableSize)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCheckBoxCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCheckBoxCell.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Selection;
 using Avalonia.Input;
 
 namespace Avalonia.Controls.Primitives
@@ -50,7 +51,12 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        public override void Realize(TreeDataGridElementFactory factory, ICell model, int columnIndex, int rowIndex)
+        public override void Realize(
+            TreeDataGridElementFactory factory,
+            ITreeDataGridSelectionInteraction? selection,
+            ICell model,
+            int columnIndex,
+            int rowIndex)
         {
             if (model is CheckBoxCell cell)
             {
@@ -63,7 +69,7 @@ namespace Avalonia.Controls.Primitives
                 throw new InvalidOperationException("Invalid cell model.");
             }
 
-            base.Realize(factory, model, columnIndex, rowIndex);
+            base.Realize(factory, selection, model, columnIndex, rowIndex);
         }
 
         protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridExpanderCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridExpanderCell.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.ComponentModel;
 using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Selection;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -48,7 +50,12 @@ namespace Avalonia.Controls.Primitives
             private set => SetAndRaise(ShowExpanderProperty, ref _showExpander, value);
         }
 
-        public override void Realize(TreeDataGridElementFactory factory, ICell model, int columnIndex, int rowIndex)
+        public override void Realize(
+            TreeDataGridElementFactory factory,
+            ITreeDataGridSelectionInteraction? selection,
+            ICell model,
+            int columnIndex,
+            int rowIndex)
         {
             if (_model is object)
                 throw new InvalidOperationException("Cell is already realized.");
@@ -73,7 +80,7 @@ namespace Avalonia.Controls.Primitives
                 throw new InvalidOperationException("Invalid cell model.");
             }
 
-            base.Realize(factory, model, columnIndex, rowIndex);
+            base.Realize(factory, selection, model, columnIndex, rowIndex);
             UpdateContent(_factory);
         }
 
@@ -112,12 +119,17 @@ namespace Avalonia.Controls.Primitives
                 }
 
                 if (_contentContainer.Child is ITreeDataGridCell innerCell)
-                    innerCell.Realize(factory, innerModel, ColumnIndex, RowIndex);
+                    innerCell.Realize(factory, GetSelection(), innerModel, ColumnIndex, RowIndex);
             }
             else if (_contentContainer.Child is ITreeDataGridCell innerCell)
             {
                 innerCell.Unrealize();
             }
+        }
+
+        private ITreeDataGridSelectionInteraction? GetSelection()
+        {
+            return this.FindAncestorOfType<TreeDataGrid>()?.SelectionInteraction;
         }
 
         private void ModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridExpanderCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridExpanderCell.cs
@@ -119,17 +119,12 @@ namespace Avalonia.Controls.Primitives
                 }
 
                 if (_contentContainer.Child is ITreeDataGridCell innerCell)
-                    innerCell.Realize(factory, GetSelection(), innerModel, ColumnIndex, RowIndex);
+                    innerCell.Realize(factory, null, innerModel, ColumnIndex, RowIndex);
             }
             else if (_contentContainer.Child is ITreeDataGridCell innerCell)
             {
                 innerCell.Unrealize();
             }
-        }
-
-        private ITreeDataGridSelectionInteraction? GetSelection()
-        {
-            return this.FindAncestorOfType<TreeDataGrid>()?.SelectionInteraction;
         }
 
         private void ModelPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -82,14 +82,17 @@ namespace Avalonia.Controls.Primitives
         protected abstract Orientation Orientation { get; }
         protected Rect Viewport { get; private set; } = s_invalidViewport;
 
-        public void BringIntoView(int index)
+        public void BringIntoView(int index, Rect? rect = null)
         {
             if (_items is null || index < 0 || index >= _items.Count)
                 return;
 
             if (GetRealizedElement(index) is Control element)
             {
-                element.BringIntoView();
+                if (rect.HasValue)
+                    element.BringIntoView(rect.Value);
+                else
+                    element.BringIntoView();
             }
             else if (this.GetVisualRoot() is ILayoutRoot root)
             {
@@ -101,16 +104,16 @@ namespace Avalonia.Controls.Primitives
 
                 // Get the expected position of the elment and put it in place.
                 var anchorU = GetOrEstimateElementPosition(index);
-                var rect = Orientation == Orientation.Horizontal ?
+                var elementRect = Orientation == Orientation.Horizontal ?
                     new Rect(anchorU, 0, _anchorElement.DesiredSize.Width, _anchorElement.DesiredSize.Height) :
                     new Rect(0, anchorU, _anchorElement.DesiredSize.Width, _anchorElement.DesiredSize.Height);
-                _anchorElement.Arrange(rect);
+                _anchorElement.Arrange(elementRect);
 
                 // If the item being brought into view was added since the last layout pass then
                 // our bounds won't be updated, so any containing scroll viewers will not have an
                 // updated extent. Do a layout pass to ensure that the containing scroll viewers
                 // will be able to scroll the new item into view.
-                if (!Bounds.Contains(rect) && !Viewport.Contains(rect))
+                if (!Bounds.Contains(elementRect) && !Viewport.Contains(elementRect))
                 {
                     _isWaitingForViewportUpdate = true;
                     root.LayoutManager.ExecuteLayoutPass();
@@ -118,9 +121,12 @@ namespace Avalonia.Controls.Primitives
                 }
 
                 // Try to bring the item into view and do a layout pass.
-                _anchorElement.BringIntoView();
+                if (rect.HasValue)
+                    _anchorElement.BringIntoView(rect.Value);
+                else
+                    _anchorElement.BringIntoView();
 
-                _isWaitingForViewportUpdate = !Viewport.Contains(rect);
+                _isWaitingForViewportUpdate = !Viewport.Contains(elementRect);
                 root.LayoutManager.ExecuteLayoutPass();
                 _isWaitingForViewportUpdate = false;
 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -151,6 +151,7 @@ namespace Avalonia.Controls.Primitives
         internal void UpdateSelection(ITreeDataGridSelectionInteraction? selection)
         {
             IsSelected = selection?.IsRowSelected(RowIndex) ?? false;
+            CellsPresenter?.UpdateSelection(selection);
         }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Selection;
 using Avalonia.Input;
+using Avalonia.LogicalTree;
 
 namespace Avalonia.Controls.Primitives
 {
     [PseudoClasses(":selected")]
-    public class TreeDataGridRow : TemplatedControl, ISelectable
+    public class TreeDataGridRow : TemplatedControl
     {
         private const double DragDistance = 3;
         private static readonly Point s_InvalidPoint = new(double.NegativeInfinity, double.NegativeInfinity);
@@ -25,8 +27,7 @@ namespace Avalonia.Controls.Primitives
         public static readonly DirectProperty<TreeDataGridRow, bool> IsSelectedProperty =
             AvaloniaProperty.RegisterDirect<TreeDataGridRow, bool>(
                 nameof(IsSelected),
-                o => o.IsSelected,
-                (o, v) => o.IsSelected = v);
+                o => o.IsSelected);
 
         public static readonly DirectProperty<TreeDataGridRow, IRows?> RowsProperty =
             AvaloniaProperty.RegisterDirect<TreeDataGridRow, IRows?>(
@@ -54,7 +55,7 @@ namespace Avalonia.Controls.Primitives
         public bool IsSelected
         {
             get => _isSelected;
-            set => SetAndRaise(IsSelectedProperty, ref _isSelected, value);
+            private set => SetAndRaise(IsSelectedProperty, ref _isSelected, value);
         }
 
         public object? Model => DataContext;
@@ -70,6 +71,7 @@ namespace Avalonia.Controls.Primitives
 
         public void Realize(
             TreeDataGridElementFactory? elementFactory,
+            ITreeDataGridSelectionInteraction? selection,
             IColumns? columns,
             IRows? rows,
             int rowIndex)
@@ -78,7 +80,9 @@ namespace Avalonia.Controls.Primitives
             Columns = columns;
             Rows = rows;
             DataContext = rows?[rowIndex].Model;
+            IsSelected = selection?.IsRowSelected(rowIndex) ?? false;
             UpdateIndex(rowIndex);
+            UpdateSelection(selection);
         }
 
         public Control? TryGetCell(int columnIndex)
@@ -96,6 +100,7 @@ namespace Avalonia.Controls.Primitives
         {
             RowIndex = -1;
             DataContext = null;
+            IsSelected = false;
             CellsPresenter?.Unrealize();
         }
 
@@ -141,6 +146,11 @@ namespace Avalonia.Controls.Primitives
             }
             
             base.OnPropertyChanged(change);
+        }
+
+        internal void UpdateSelection(ITreeDataGridSelectionInteraction? selection)
+        {
+            IsSelected = selection?.IsRowSelected(RowIndex) ?? false;
         }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -80,7 +81,7 @@ namespace Avalonia.Controls.Primitives
 
         internal void UpdateSelection(ITreeDataGridSelectionInteraction? selection)
         {
-            foreach (var element in VisualChildren)
+            foreach (var element in RealizedElements)
             {
                 if (element is TreeDataGridRow { RowIndex: >= 0 } row)
                     row.UpdateSelection(selection);
@@ -100,7 +101,7 @@ namespace Avalonia.Controls.Primitives
 
         private ITreeDataGridSelectionInteraction? GetSelection()
         {
-            return (TemplatedParent as TreeDataGrid)?.SelectionInteraction ?? null;
+            return this.FindAncestorOfType<TreeDataGrid>()?.SelectionInteraction;
         }
 
         public int GetChildIndex(ILogical child)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
-using Avalonia.Data;
 using Avalonia.Layout;
 using Avalonia.LogicalTree;
 
@@ -15,14 +14,7 @@ namespace Avalonia.Controls.Primitives
                 o => o.Columns,
                 (o, v) => o.Columns = v);
 
-        public static readonly DirectProperty<TreeDataGridRowsPresenter, ITreeDataGridSelectionInteraction?> SelectionProperty =
-            AvaloniaProperty.RegisterDirect<TreeDataGridRowsPresenter, ITreeDataGridSelectionInteraction?>(
-                nameof(Selection),
-                o => o.Selection,
-                (o, v) => o.Selection = v);
-
         private IColumns? _columns;
-        private ITreeDataGridSelectionInteraction? _selection;
 
         public event EventHandler<ChildIndexChangedEventArgs>? ChildIndexChanged;
 
@@ -30,35 +22,6 @@ namespace Avalonia.Controls.Primitives
         {
             get => _columns;
             set => SetAndRaise(ColumnsProperty, ref _columns, value);
-        }
-
-        public ITreeDataGridSelectionInteraction? Selection
-        {
-            get => _selection;
-            set
-            {
-                if (_selection != value)
-                {
-                    var oldValue = _selection;
-
-                    if (_selection is object)
-                    {
-                        _selection.SelectionChanged -= OnSelectionChanged;
-                    }
-
-                    _selection = value;
-
-                    if (_selection is object)
-                    {
-                        _selection.SelectionChanged += OnSelectionChanged;
-                    }
-
-                    RaisePropertyChanged(
-                        SelectionProperty,
-                        oldValue,
-                        _selection);
-                }
-            }
         }
 
         protected override Orientation Orientation => Orientation.Vertical;
@@ -71,8 +34,7 @@ namespace Avalonia.Controls.Primitives
         protected override void RealizeElement(Control element, IRow rowModel, int index)
         {
             var row = (TreeDataGridRow)element;
-            row.Realize(ElementFactory, Columns, (IRows?)Items, index);
-            row.IsSelected = _selection?.IsRowSelected(rowModel) == true;
+            row.Realize(ElementFactory, GetSelection(), Columns, (IRows?)Items, index);
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, index));
         }
 
@@ -86,17 +48,6 @@ namespace Avalonia.Controls.Primitives
         {
             ((TreeDataGridRow)element).Unrealize();
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, ((TreeDataGridRow)element).RowIndex));
-        }
-
-        private void UpdateSelection()
-        {
-            foreach (var element in VisualChildren)
-            {
-                if (element is TreeDataGridRow { RowIndex: >= 0 } row)
-                {
-                    row.IsSelected = _selection?.IsRowSelected(row.RowIndex) == true;
-                }
-            }
         }
 
         protected override Size ArrangeOverride(Size finalSize)
@@ -127,6 +78,15 @@ namespace Avalonia.Controls.Primitives
             base.OnPropertyChanged(change);
         }
 
+        internal void UpdateSelection(ITreeDataGridSelectionInteraction? selection)
+        {
+            foreach (var element in VisualChildren)
+            {
+                if (element is TreeDataGridRow { RowIndex: >= 0 } row)
+                    row.UpdateSelection(selection);
+            }
+        }
+
         private void OnColumnLayoutInvalidated(object? sender, EventArgs e)
         {
             InvalidateMeasure();
@@ -138,9 +98,9 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        private void OnSelectionChanged(object? sender, EventArgs e)
+        private ITreeDataGridSelectionInteraction? GetSelection()
         {
-            UpdateSelection();
+            return (TemplatedParent as TreeDataGrid)?.SelectionInteraction ?? null;
         }
 
         public int GetChildIndex(ILogical child)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTemplateCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTemplateCell.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Selection;
 using Avalonia.Controls.Templates;
 using Avalonia.LogicalTree;
 
@@ -31,10 +32,15 @@ namespace Avalonia.Controls.Primitives
             set => SetAndRaise(ContentTemplateProperty, ref _contentTemplate, value);
         }
 
-        public override void Realize(TreeDataGridElementFactory factory, ICell model, int columnIndex, int rowIndex)
+        public override void Realize(
+            TreeDataGridElementFactory factory,
+            ITreeDataGridSelectionInteraction? selection, 
+            ICell model,
+            int columnIndex,
+            int rowIndex)
         {
             DataContext = model;
-            base.Realize(factory, model, columnIndex, rowIndex);
+            base.Realize(factory, selection, model, columnIndex, rowIndex);
         }
 
         public override void Unrealize()

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Selection;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
@@ -42,12 +43,17 @@ namespace Avalonia.Controls.Primitives
 
         protected override bool CanEdit => _canEdit;
 
-        public override void Realize(TreeDataGridElementFactory factory, ICell model, int columnIndex, int rowIndex)
+        public override void Realize(
+            TreeDataGridElementFactory factory,
+            ITreeDataGridSelectionInteraction? selection,
+            ICell model,
+            int columnIndex,
+            int rowIndex)
         {
             _canEdit = model.CanEdit;
             Value = model.Value?.ToString();
             TextTrimming = (model as ITextCell)?.TextTrimming ?? TextTrimming.CharacterEllipsis;
-            base.Realize(factory, model, columnIndex, rowIndex);
+            base.Realize(factory, selection, model, columnIndex, rowIndex);
             SubscribeToModelChanges();
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
@@ -43,8 +43,20 @@ namespace Avalonia.Controls.Selection
         /// <summary>
         /// Checks whether the specified cell is selected.
         /// </summary>
-        /// <param name="columnIndex">The column index of the cell.</param>
-        /// <param name="rowIndex">The model index of the cell.</param>
-        public bool IsSelected(int columnIndex, IndexPath rowIndex);
+        /// <param name="index">The index of the cell.</param>
+        bool IsSelected(CellIndex index);
+
+        /// <summary>
+        /// Sets the current selection to the specified range of cells.
+        /// </summary>
+        /// <param name="start">The index of the cell from which the selection should start.</param>
+        /// <param name="columnCount">The number of columns in the selection.</param>
+        /// <param name="rowCount">The number of rows in the selection.</param>
+        /// <remarks>
+        /// This method clears the current selection and selects the specified range of cells.
+        /// Note that if the <see cref="ITreeDataGridSource"/> is currently sorted then the
+        /// resulting selection may not be contiguous in the data source.
+        /// </remarks>
+        void SetSelectedRange(CellIndex start, int columnCount, int rowCount);
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
@@ -20,15 +20,5 @@ namespace Avalonia.Controls.Selection
         /// Gets the currently selected cells.
         /// </summary>
         IReadOnlyList<ICell> SelectedCells { get; }
-
-        /// <summary>
-        /// Gets the currently selected columns.
-        /// </summary>
-        ITreeDataGridColumnSelectionModel SelectedColumns { get; }
-
-        /// <summary>
-        /// Gets the currently selected rows.
-        /// </summary>
-        ITreeDataGridRowSelectionModel<T> SelectedRows { get; }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
@@ -26,6 +26,11 @@ namespace Avalonia.Controls.Selection
         bool SingleSelect { get; set; }
 
         /// <summary>
+        /// Gets or sets the index of the currently selected cell.
+        /// </summary>
+        CellIndex SelectedIndex { get; set; }
+
+        /// <summary>
         /// Gets the indexes of the currently selected cells.
         /// </summary>
         IReadOnlyList<CellIndex> SelectedIndexes { get; }
@@ -34,5 +39,12 @@ namespace Avalonia.Controls.Selection
         /// Occurs when the cell selection changes.
         /// </summary>
         new event EventHandler<TreeDataGridCellSelectionChangedEventArgs<T>>? SelectionChanged;
+
+        /// <summary>
+        /// Checks whether the specified cell is selected.
+        /// </summary>
+        /// <param name="columnIndex">The column index of the cell.</param>
+        /// <param name="rowIndex">The model index of the cell.</param>
+        public bool IsSelected(int columnIndex, IndexPath rowIndex);
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
@@ -1,13 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using Avalonia.Controls.Models.TreeDataGrid;
 
 namespace Avalonia.Controls.Selection
 {
+    /// <summary>
+    /// Maintains the cell selection state for an <see cref="ITreeDataGridSource"/>.
+    /// </summary>
     public interface ITreeDataGridCellSelectionModel : ITreeDataGridSelection
     {
+        /// <summary>
+        /// Occurs when the cell selection changes.
+        /// </summary>
+        event EventHandler<TreeDataGridCellSelectionChangedEventArgs>? SelectionChanged;
     }
 
+    /// <summary>
+    /// Maintains the cell selection state for an <see cref="ITreeDataGridSource"/>.
+    /// </summary>
     public interface ITreeDataGridCellSelectionModel<T> : ITreeDataGridCellSelectionModel
         where T : class
     {
@@ -17,8 +26,13 @@ namespace Avalonia.Controls.Selection
         bool SingleSelect { get; set; }
 
         /// <summary>
-        /// Gets the currently selected cells.
+        /// Gets the indexes of the currently selected cells.
         /// </summary>
-        IReadOnlyList<ICell> SelectedCells { get; }
+        IReadOnlyList<CellIndex> SelectedIndexes { get; }
+
+        /// <summary>
+        /// Occurs when the cell selection changes.
+        /// </summary>
+        new event EventHandler<TreeDataGridCellSelectionChangedEventArgs<T>>? SelectionChanged;
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridCellSelectionModel.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Avalonia.Controls.Models.TreeDataGrid;
+
+namespace Avalonia.Controls.Selection
+{
+    public interface ITreeDataGridCellSelectionModel : ITreeDataGridSelection
+    {
+    }
+
+    public interface ITreeDataGridCellSelectionModel<T> : ITreeDataGridCellSelectionModel
+        where T : class
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether only a single cell can be selected at a time.
+        /// </summary>
+        bool SingleSelect { get; set; }
+
+        /// <summary>
+        /// Gets the currently selected cells.
+        /// </summary>
+        IReadOnlyList<ICell> SelectedCells { get; }
+
+        /// <summary>
+        /// Gets the currently selected columns.
+        /// </summary>
+        ITreeDataGridColumnSelectionModel SelectedColumns { get; }
+
+        /// <summary>
+        /// Gets the currently selected rows.
+        /// </summary>
+        ITreeDataGridRowSelectionModel<T> SelectedRows { get; }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridColumnSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridColumnSelectionModel.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using Avalonia.Controls.Models.TreeDataGrid;
+
+namespace Avalonia.Controls.Selection
+{
+    public interface ITreeDataGridColumnSelectionModel : ISelectionModel
+    {
+        new IReadOnlyList<IColumn?> SelectedItems { get; }
+        new IColumn? SelectedItem { get; set; }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridSelectionInteraction.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/ITreeDataGridSelectionInteraction.cs
@@ -12,8 +12,9 @@ namespace Avalonia.Controls.Selection
     {
         public event EventHandler? SelectionChanged;
 
-        bool IsRowSelected(IRow rowModel);
-        bool IsRowSelected(int rowIndex);
+        bool IsCellSelected(int columnIndex, int rowIndex) => false;
+        bool IsRowSelected(IRow rowModel) => false;
+        bool IsRowSelected(int rowIndex) => false;
         public void OnKeyDown(TreeDataGrid sender, KeyEventArgs e) { }
         public void OnPreviewKeyDown(TreeDataGrid sender, KeyEventArgs e) { }
         public void OnKeyUp(TreeDataGrid sender, KeyEventArgs e) { }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/IndexRanges.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/IndexRanges.cs
@@ -44,8 +44,7 @@ namespace Avalonia.Controls.Selection
                 _ranges.Add(parent, ranges);
             }
 
-            IndexRange.Add(ranges, new IndexRange(index[^1]));
-            ++Count;
+            Count += IndexRange.Add(ranges, new IndexRange(index[^1]));
         }
 
         public void Add(in IndexPath parent, in IndexRange range)

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/SelectedCellIndexes.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/SelectedCellIndexes.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Avalonia.Controls.Selection
+{
+    internal class SelectedCellIndexes : IReadOnlyList<CellIndex>
+    {
+        private readonly ITreeDataGridColumnSelectionModel _selectedColumns;
+        private readonly ITreeDataGridRowSelectionModel _selectedRows;
+
+        public SelectedCellIndexes(
+            ITreeDataGridColumnSelectionModel selectedColumns,
+            ITreeDataGridRowSelectionModel selectedRows)
+        {
+            _selectedColumns = selectedColumns;
+            _selectedRows = selectedRows;
+        }
+
+        public CellIndex this[int index] 
+        { 
+            get
+            {
+                if (index < 0 || index >= Count)
+                    throw new IndexOutOfRangeException("The index was out of range.");
+                var column = _selectedColumns.SelectedIndexes[index % _selectedColumns.Count];
+                var row = _selectedRows.SelectedIndexes[index / _selectedColumns.Count];
+                return new(column, row);
+            }
+        }
+
+        public int Count => _selectedColumns.Count * _selectedRows.Count;
+
+        public IEnumerator<CellIndex> GetEnumerator()
+        {
+            for (var i = 0; i < Count; ++i)
+                yield return this[i];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            for (var i = 0; i < Count; ++i)
+                yield return this[i];
+        }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionChangedEventArgs.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionChangedEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Avalonia.Controls.Selection
+{
+    /// <summary>
+    /// Provides data for the <see cref="ITreeDataGridCellSelectionModel.SelectionChanged"/> event.
+    /// </summary>
+    public class TreeDataGridCellSelectionChangedEventArgs : EventArgs
+    {
+    }
+
+    /// <summary>
+    /// Provides data for the <see cref="ITreeDataGridCellSelectionModel{T}.SelectionChanged"/> event.
+    /// </summary>
+    /// <typeparam name="T">The model type.</typeparam>
+    public class TreeDataGridCellSelectionChangedEventArgs<T> : TreeDataGridCellSelectionChangedEventArgs
+        where T : class
+    {
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
@@ -127,6 +127,11 @@ namespace Avalonia.Controls.Selection
                 Select(columnIndex, rowIndex);
             else
                 SelectFromAnchorTo(columnIndex, rowIndex);
+
+            sender.ColumnHeadersPresenter?.BringIntoView(columnIndex);
+            sender.RowsPresenter?.BringIntoView(
+                rowIndex,
+                sender.ColumnHeadersPresenter?.TryGetElement(columnIndex)?.Bounds);
         }
 
         void ITreeDataGridSelectionInteraction.OnPointerPressed(TreeDataGrid sender, PointerPressedEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Input;
 
 namespace Avalonia.Controls.Selection
 {
@@ -9,10 +10,14 @@ namespace Avalonia.Controls.Selection
         ITreeDataGridSelectionInteraction
         where TModel : class
     {
+        private static readonly Point s_InvalidPoint = new(double.NegativeInfinity, double.NegativeInfinity);
+        private readonly ITreeDataGridSource<TModel> _source;
         private EventHandler? _viewSelectionChanged;
+        private Point _pressedPoint = s_InvalidPoint;
 
         public TreeDataGridCellSelectionModel(ITreeDataGridSource<TModel> source)
         {
+            _source = source;
             SelectedCells = Array.Empty<ICell>();
             SelectedColumns = new TreeDataGridColumnSelectionModel(source.Columns);
             SelectedRows = new TreeDataGridRowSelectionModel<TModel>(source);
@@ -38,6 +43,46 @@ namespace Avalonia.Controls.Selection
         {
             add => _viewSelectionChanged += value;
             remove => _viewSelectionChanged -= value;
+        }
+
+        public void Select(int columnIndex, IndexPath rowIndex)
+        {
+            SelectedColumns.Select(columnIndex);
+            SelectedRows.Select(rowIndex);
+            _viewSelectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        bool ITreeDataGridSelectionInteraction.IsCellSelected(int columnIndex, int rowIndex)
+        {
+            return IsSelected(columnIndex, rowIndex);
+        }
+
+        void ITreeDataGridSelectionInteraction.OnPointerPressed(TreeDataGrid sender, PointerPressedEventArgs e)
+        {
+            // Select a cell on pointer pressed if:
+            //
+            // - It's a mouse click, not touch: we don't want to select on touch scroll gesture start
+            //
+            // Otherwise select on pointer release.
+            if (!e.Handled &&
+                e.Pointer.Type == PointerType.Mouse &&
+                e.Source is Control source &&
+                sender.TryGetCell(source, out var cell) &&
+                _source.Rows.RowIndexToModelIndex(cell.RowIndex) is { } modelIndex)
+            {
+                Select(cell.ColumnIndex, modelIndex);
+            }
+            else
+            {
+                _pressedPoint = e.GetPosition(sender);
+            }
+        }
+
+        private bool IsSelected(int columnIndex, int rowIndex)
+        {
+            if (_source.Rows.RowIndexToModelIndex(rowIndex) is { } modelIndex)
+                return SelectedColumns.IsSelected(columnIndex) && SelectedRows.IsSelected(rowIndex);
+            return false;
         }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
@@ -197,7 +197,7 @@ namespace Avalonia.Controls.Selection
             return _selectedColumns.IsSelected(columnIndex) && _selectedRows.IsSelected(modelIndex);
         }
 
-        protected void Select(int columnIndex, int rowIndex)
+        private void Select(int columnIndex, int rowIndex)
         {
             var modelIndex = _source.Rows.RowIndexToModelIndex(rowIndex);
             Select(columnIndex, rowIndex, modelIndex);
@@ -212,7 +212,7 @@ namespace Avalonia.Controls.Selection
             EndBatchUpdate();
         }
 
-        protected void SelectFromAnchorTo(int columnIndex, int rowIndex)
+        private void SelectFromAnchorTo(int columnIndex, int rowIndex)
         {
             var anchorColumnIndex = _selectedColumns.AnchorIndex;
             var anchorModelIndex = _selectedRows.AnchorIndex;

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
@@ -41,6 +41,16 @@ namespace Avalonia.Controls.Selection
             set => _selectedColumns.SingleSelect = _selectedRows.SingleSelect = value;
         }
 
+        public CellIndex SelectedIndex
+        {
+            get => new(_selectedColumns.SelectedIndex, _selectedRows.SelectedIndex);
+            set
+            {
+                var rowIndex = _source.Rows.ModelIndexToRowIndex(value.RowIndex);
+                Select(value.ColumnIndex, rowIndex, value.RowIndex);
+            }
+        }
+
         public IReadOnlyList<CellIndex> SelectedIndexes => _selectedIndexes;
 
         IEnumerable? ITreeDataGridSelection.Source
@@ -66,12 +76,6 @@ namespace Avalonia.Controls.Selection
         public bool IsSelected(int columnIndex, IndexPath rowIndex)
         {
             return _selectedColumns.IsSelected(columnIndex) && _selectedRows.IsSelected(rowIndex);
-        }
-
-        public void Select(int columnIndex, IndexPath rowIndex)
-        {
-            var ri = _source.Rows.ModelIndexToRowIndex(rowIndex);
-            Select(columnIndex, ri, rowIndex);
         }
 
         bool ITreeDataGridSelectionInteraction.IsCellSelected(int columnIndex, int rowIndex)
@@ -237,9 +241,9 @@ namespace Avalonia.Controls.Selection
 
             BeginBatchUpdate();
 
-            _selectedColumns.Clear();
+            _selectedColumns.SelectedIndex = anchorColumnIndex;
             _selectedColumns.SelectRange(anchorColumnIndex, columnIndex);
-            _selectedRows.Clear();
+            _selectedRows.SelectedIndex = anchorModelIndex;
 
             for (var i = Math.Min(anchorRowIndex, rowIndex); i <= Math.Max(anchorRowIndex, rowIndex); ++i)
             {

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using Avalonia.Controls.Models.TreeDataGrid;
+
+namespace Avalonia.Controls.Selection
+{
+    public class TreeDataGridCellSelectionModel<TModel> : ITreeDataGridCellSelectionModel<TModel>
+        where TModel : class
+    {
+        public TreeDataGridCellSelectionModel(ITreeDataGridSource<TModel> source)
+        {
+            SelectedCells = Array.Empty<ICell>();
+            SelectedColumns = new TreeDataGridColumnSelectionModel(source.Columns);
+            SelectedRows = new TreeDataGridRowSelectionModel<TModel>(source);
+        }
+
+        public bool SingleSelect
+        {
+            get => SelectedRows.SingleSelect;
+            set => SelectedColumns.SingleSelect = SelectedRows.SingleSelect = value;
+        }
+
+        public IReadOnlyList<ICell> SelectedCells { get; }
+        public ITreeDataGridColumnSelectionModel SelectedColumns { get; }
+        public ITreeDataGridRowSelectionModel<TModel> SelectedRows { get; }
+
+        IEnumerable? ITreeDataGridSelection.Source
+        {
+            get => ((ITreeDataGridSelection)SelectedRows).Source;
+            set => ((ITreeDataGridSelection)SelectedRows).Source = value;
+        }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
@@ -90,6 +90,7 @@ namespace Avalonia.Controls.Selection
             SetSelectedRange(
                 start.ColumnIndex,
                 _source.Rows.ModelIndexToRowIndex(start.RowIndex),
+                start.RowIndex,
                 columnCount,
                 rowCount);
         }
@@ -241,11 +242,17 @@ namespace Avalonia.Controls.Selection
             SetSelectedRange(
                 anchorColumnIndex,
                 anchorRowIndex,
+                _selectedRows.AnchorIndex,
                 (columnIndex - anchorColumnIndex) + 1,
                 (rowIndex - anchorRowIndex) + 1);
         }
 
-        private void SetSelectedRange(int columnIndex, int rowIndex, int columnCount, int rowCount)
+        private void SetSelectedRange(
+            int columnIndex,
+            int rowIndex,
+            IndexPath modelIndex,
+            int columnCount,
+            int rowCount)
         {
             var endColumnIndex = columnIndex + columnCount - 1;
             var endRowIndex = rowIndex + rowCount - 1;
@@ -261,7 +268,7 @@ namespace Avalonia.Controls.Selection
                 _selectedRows.Select(_source.Rows.RowIndexToModelIndex(i));
             }
 
-            _selectedRows.AnchorIndex = rowIndex;
+            _selectedRows.AnchorIndex = modelIndex;
             _rangeAnchor = (endColumnIndex, endRowIndex);
 
             EndBatchUpdate();

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
@@ -197,7 +197,7 @@ namespace Avalonia.Controls.Selection
             return _selectedColumns.IsSelected(columnIndex) && _selectedRows.IsSelected(modelIndex);
         }
 
-        private void Select(int columnIndex, int rowIndex)
+        protected void Select(int columnIndex, int rowIndex)
         {
             var modelIndex = _source.Rows.RowIndexToModelIndex(rowIndex);
             Select(columnIndex, rowIndex, modelIndex);
@@ -212,7 +212,7 @@ namespace Avalonia.Controls.Selection
             EndBatchUpdate();
         }
 
-        private void SelectFromAnchorTo(int columnIndex, int rowIndex)
+        protected void SelectFromAnchorTo(int columnIndex, int rowIndex)
         {
             var anchorColumnIndex = _selectedColumns.AnchorIndex;
             var anchorModelIndex = _selectedRows.AnchorIndex;

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridCellSelectionModel.cs
@@ -5,9 +5,12 @@ using Avalonia.Controls.Models.TreeDataGrid;
 
 namespace Avalonia.Controls.Selection
 {
-    public class TreeDataGridCellSelectionModel<TModel> : ITreeDataGridCellSelectionModel<TModel>
+    public class TreeDataGridCellSelectionModel<TModel> : ITreeDataGridCellSelectionModel<TModel>,
+        ITreeDataGridSelectionInteraction
         where TModel : class
     {
+        private EventHandler? _viewSelectionChanged;
+
         public TreeDataGridCellSelectionModel(ITreeDataGridSource<TModel> source)
         {
             SelectedCells = Array.Empty<ICell>();
@@ -29,6 +32,12 @@ namespace Avalonia.Controls.Selection
         {
             get => ((ITreeDataGridSelection)SelectedRows).Source;
             set => ((ITreeDataGridSelection)SelectedRows).Source = value;
+        }
+
+        event EventHandler? ITreeDataGridSelectionInteraction.SelectionChanged
+        {
+            add => _viewSelectionChanged += value;
+            remove => _viewSelectionChanged -= value;
         }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridColumnSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridColumnSelectionModel.cs
@@ -1,0 +1,13 @@
+﻿using Avalonia.Controls.Models.TreeDataGrid;
+
+namespace Avalonia.Controls.Selection
+{
+    public class TreeDataGridColumnSelectionModel : SelectionModel<IColumn>,
+        ITreeDataGridColumnSelectionModel
+    {
+        public TreeDataGridColumnSelectionModel(IColumns columns)
+            : base(columns)
+        {
+        }
+    }
+}

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -113,7 +113,6 @@ namespace Avalonia.Controls.Selection
                     }
                 }
             }
-
         }
 
         protected void HandleTextInput(string? text, TreeDataGrid treeDataGrid, int selectedRowIndex)

--- a/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/Fluent.axaml
@@ -13,5 +13,9 @@
     <Setter Property="Background" Value="Transparent"/>
     <Setter Property="MinHeight" Value="25"/>
   </Style>
-  
+
+  <Style Selector=":is(TreeDataGridCell):selected">
+    <Setter Property="Background" Value="{DynamicResource SystemControlHighlightListAccentLowBrush}"/>
+  </Style>
+
 </Styles>

--- a/src/Avalonia.Controls.TreeDataGrid/Themes/FluentControls.axaml
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/FluentControls.axaml
@@ -33,8 +33,7 @@
               <TreeDataGridRowsPresenter Name="PART_RowsPresenter"
                                          Columns="{TemplateBinding Columns}"
                                          ElementFactory="{TemplateBinding ElementFactory}"
-                                         Items="{TemplateBinding Rows}"
-                                         Selection="{TemplateBinding SelectionInteraction}"/>
+                                         Items="{TemplateBinding Rows}"/>
             </ScrollViewer>
           </DockPanel>
         </Border>

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -243,6 +243,20 @@ namespace Avalonia.Controls
             return RowsPresenter?.TryGetElement(rowIndex) as TreeDataGridRow;
         }
 
+        public bool TryGetCell(Control? element, [MaybeNullWhen(false)] out TreeDataGridCell result)
+        {
+            if (element.FindAncestorOfType<TreeDataGridCell>(true) is { } cell && 
+                cell.ColumnIndex >= 0 &&
+                cell.RowIndex >= 0)
+            {
+                result = cell;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+
         public bool TryGetRow(Control? element, [MaybeNullWhen(false)] out TreeDataGridRow result)
         {
             if (element is TreeDataGridRow row && row.RowIndex >= 0)

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -180,31 +180,26 @@ namespace Avalonia.Controls
             {
                 if (_source != value)
                 {
-                    if (value != null)
-                    {
-                        value.Sorted += Source_Sorted;
-                    }
-
+                    if (SelectionInteraction != null)
+                        SelectionInteraction.SelectionChanged -= OnSelectionInteractionChanged;
                     if (_source != null)
-                    {
-                        _source.Sorted -= Source_Sorted;
-                    }
-
-                    void Source_Sorted()
-                    {
-                        RowsPresenter?.RecycleAllElements();
-                        RowsPresenter?.InvalidateMeasure();
-                    }
+                        _source.Sorted -= OnSourceSorted;
 
                     var oldSource = _source;
                     _source = value;
                     Columns = _source?.Columns;
                     Rows = _source?.Rows;
-                    SelectionInteraction = value?.Selection as ITreeDataGridSelectionInteraction;
+                    SelectionInteraction = _source?.Selection as ITreeDataGridSelectionInteraction;
+
+                    if (_source != null)
+                        _source.Sorted += OnSourceSorted;
+                    if (SelectionInteraction != null)
+                        SelectionInteraction.SelectionChanged += OnSelectionInteractionChanged;
+
                     RaisePropertyChanged(
                         SourceProperty,
                         oldSource,
-                        oldSource);
+                        _source);
                 }
             }
         }
@@ -679,6 +674,17 @@ namespace Avalonia.Controls
                 else
                     scroll.LineDown();
             }
+        }
+
+        private void OnSelectionInteractionChanged(object? sender, EventArgs e)
+        {
+            RowsPresenter?.UpdateSelection(SelectionInteraction);
+        }
+
+        private void OnSourceSorted()
+        {
+            RowsPresenter?.RecycleAllElements();
+            RowsPresenter?.InvalidateMeasure();
         }
 
         private static TreeDataGridRowDropPosition GetDropPosition(

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
@@ -415,6 +415,20 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 Assert.Equal(0, raised);
             }
+
+            [Fact]
+            public void Selecting_Item_Twice_Results_In_Correct_Count()
+            {
+                var target = CreateTarget();
+
+                using (target.BatchUpdate())
+                {
+                    target.SelectedIndex = new IndexPath(1);
+                    target.Select(new IndexPath(1));
+                }
+
+                Assert.Equal(1, target.Count);
+            }
         }
 
         public class Deselect

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TestTemplates.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TestTemplates.cs
@@ -79,7 +79,6 @@ namespace Avalonia.Controls.TreeDataGridTests
                                 [!TreeDataGridRowsPresenter.ColumnsProperty] = x[!TreeDataGrid.ColumnsProperty],
                                 [!TreeDataGridRowsPresenter.ElementFactoryProperty] = x[!TreeDataGrid.ElementFactoryProperty],
                                 [!TreeDataGridRowsPresenter.ItemsProperty] = x[!TreeDataGrid.RowsProperty],
-                                [!TreeDataGridRowsPresenter.SelectionProperty] = x[!TreeDataGrid.SelectionInteractionProperty],
                             }.RegisterInNameScope(ns),
                         }.RegisterInNameScope(ns)
                     }


### PR DESCRIPTION
Adds a cell selection mode to `TreeDataGrid`:

```csharp
var source = new FlatTreeDataGridSource<Foo>(_data)
{
    // Columns
}

source.Selection =  new TreeDataGridCellSelectionModel<Foo>(Source)
{
    SingleSelect = false,
};
```

TODO:

- [x] Runtime changing of selection model
- [ ] ~~Ctrl+A select all~~ not implemented for row selection either so will do it in a separate PR
- [x] Scroll when selecting cells with keyboard
- [x] Docs