### PR TITLE
Fix of duplication of the selected row

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/RealizedStackElements.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/RealizedStackElements.cs
@@ -412,7 +412,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         /// <param name="index">The index in the source collection of new first element.</param>
         /// <param name="recycleElement">A method used to recycle elements.</param>
-        public void RecycleElementsBefore(int index, Action<Control, int> recycleElement)
+        public void RecycleElementsBefore(int index, Action<Control> recycleElement)
         {
             if (index <= FirstIndex || _elements is null || _elements.Count == 0)
                 return;
@@ -430,7 +430,7 @@ namespace Avalonia.Controls.Primitives
                     if (_elements[i] is Control e)
                     {
                         _elements[i] = null;
-                        recycleElement(e, i + FirstIndex);
+                        recycleElement(e);
                     }
                 }
 
@@ -445,7 +445,7 @@ namespace Avalonia.Controls.Primitives
         /// </summary>
         /// <param name="index">The index in the source collection of new last element.</param>
         /// <param name="recycleElement">A method used to recycle elements.</param>
-        public void RecycleElementsAfter(int index, Action<Control, int> recycleElement)
+        public void RecycleElementsAfter(int index, Action<Control> recycleElement)
         {
             if (index >= LastIndex || _elements is null || _elements.Count == 0)
                 return;
@@ -464,7 +464,7 @@ namespace Avalonia.Controls.Primitives
                     if (_elements[i] is Control e)
                     {
                         _elements[i] = null;
-                        recycleElement(e, i + FirstIndex);
+                        recycleElement(e);
                     }
                 }
 
@@ -477,7 +477,7 @@ namespace Avalonia.Controls.Primitives
         /// Recycles all realized elements.
         /// </summary>
         /// <param name="recycleElement">A method used to recycle elements.</param>
-        public void RecycleAllElements(Action<Control, int> recycleElement)
+        public void RecycleAllElements(Action<Control> recycleElement)
         {
             if (_elements is null || _elements.Count == 0)
                 return;
@@ -487,7 +487,7 @@ namespace Avalonia.Controls.Primitives
                 if (_elements[i] is Control e)
                 {
                     _elements[i] = null;
-                    recycleElement(e, i + FirstIndex);
+                    recycleElement(e);
                 }
             }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -32,7 +32,6 @@ namespace Avalonia.Controls.Primitives
                 (o, v) => o.Items = v);
 #pragma warning restore AVP1002
         private static readonly Rect s_invalidViewport = new(double.PositiveInfinity, double.PositiveInfinity, 0, 0);
-        //private readonly Action<Control, int> _recycleElement;
         private readonly Action<Control> _recycleElementOnItemRemoved;
         private readonly Action<Control, int, int> _updateElementIndex;
         private int _scrollToIndex = -1;
@@ -45,8 +44,6 @@ namespace Avalonia.Controls.Primitives
         private RealizedStackElements? _realizedElements;
         private ScrollViewer? _scrollViewer;
         private double _lastEstimatedElementSizeU = 25;
-        //private Control? _unrealizedFocusedElement;
-        //private int _unrealizedFocusedIndex = -1;
 
         public TreeDataGridPresenterBase()
         {
@@ -604,29 +601,6 @@ namespace Avalonia.Controls.Primitives
                 double.IsFinite(availableSize.Height) ? availableSize.Height : 0); 
         }
 
-        [Obsolete($"Use {nameof(RecycleElementOnItemRemoved)} instead")]
-        private void RecycleElement(Control element, int index)
-        {
-            RecycleElementOnItemRemoved(element);
-            
-            //if (element.IsKeyboardFocusWithin)
-            //{
-            //    // This optimization does not work correctly!
-            //    // Because of this the selected object is not reset during redrawing
-            //    // Look at 'Realized' count on Debug console
-            //    //
-            //    _unrealizedFocusedElement = element;
-            //    _unrealizedFocusedIndex = index;
-            //    _unrealizedFocusedElement.LostFocus += OnUnrealizedFocusedElementLostFocus;
-            //}
-            //else
-            //{
-            //    UnrealizeElement(element);
-            //    element.IsVisible = false;
-            //    ElementFactory!.RecycleElement(element);
-            //}
-        }
-
         private void RecycleElementOnItemRemoved(Control element)
         {
             UnrealizeElement(element);
@@ -679,17 +653,6 @@ namespace Avalonia.Controls.Primitives
                     break;
             }
         }
-
-        //private void OnUnrealizedFocusedElementLostFocus(object? sender, RoutedEventArgs e)
-        //{
-        //    if (_unrealizedFocusedElement is null || sender != _unrealizedFocusedElement)
-        //        return;
-
-        //    _unrealizedFocusedElement.LostFocus -= OnUnrealizedFocusedElementLostFocus;
-        //    RecycleElement(_unrealizedFocusedElement, _unrealizedFocusedIndex);
-        //    _unrealizedFocusedElement = null;
-        //    _unrealizedFocusedIndex = -1;
-        //}
 
         private static bool HasInfinity(Size s) => double.IsInfinity(s.Width) || double.IsInfinity(s.Height);
 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Layout;
@@ -16,6 +17,7 @@ namespace Avalonia.Controls.Primitives
                 (o, v) => o.Columns = v);
 
         private IColumns? _columns;
+        private int _realizedCount;
 
         public event EventHandler<ChildIndexChangedEventArgs>? ChildIndexChanged;
 
@@ -34,6 +36,9 @@ namespace Avalonia.Controls.Primitives
 
         protected override void RealizeElement(Control element, IRow rowModel, int index)
         {
+            _realizedCount++;
+            Debug.WriteLine($"\t\t/-------{Environment.TickCount64}: {nameof(RealizeElement)} \t--- Realized: {_realizedCount}");
+
             var row = (TreeDataGridRow)element;
             row.Realize(ElementFactory, GetSelection(), Columns, (IRows?)Items, index);
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, index));
@@ -47,6 +52,9 @@ namespace Avalonia.Controls.Primitives
 
         protected override void UnrealizeElement(Control element)
         {
+            _realizedCount--;
+            Debug.WriteLine($"\t\t/-------{Environment.TickCount64}: {nameof(UnrealizeElement)} \t--- Realized: {_realizedCount}");
+
             ((TreeDataGridRow)element).Unrealize();
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, ((TreeDataGridRow)element).RowIndex));
         }

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -17,7 +17,6 @@ namespace Avalonia.Controls.Primitives
                 (o, v) => o.Columns = v);
 
         private IColumns? _columns;
-        private int _realizedCount;
 
         public event EventHandler<ChildIndexChangedEventArgs>? ChildIndexChanged;
 
@@ -36,9 +35,6 @@ namespace Avalonia.Controls.Primitives
 
         protected override void RealizeElement(Control element, IRow rowModel, int index)
         {
-            _realizedCount++;
-            Debug.WriteLine($"\t\t/-------{Environment.TickCount64}: {nameof(RealizeElement)} \t--- Realized: {_realizedCount}");
-
             var row = (TreeDataGridRow)element;
             row.Realize(ElementFactory, GetSelection(), Columns, (IRows?)Items, index);
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, index));
@@ -52,9 +48,6 @@ namespace Avalonia.Controls.Primitives
 
         protected override void UnrealizeElement(Control element)
         {
-            _realizedCount--;
-            Debug.WriteLine($"\t\t/-------{Environment.TickCount64}: {nameof(UnrealizeElement)} \t--- Realized: {_realizedCount}");
-
             ((TreeDataGridRow)element).Unrealize();
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, ((TreeDataGridRow)element).RowIndex));
         }


### PR DESCRIPTION
Fixes #200 
This commit removes base implementation of method RecycleElement and fields associated with this method.
The duplication of the selected object is stably reproduced when the window is resized or when the table is scrolled further.