### PR TITLE
Issue196

### DIFF
--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -134,7 +134,8 @@
                       Source="{Binding DragDrop.Source}"
                       AutoDragDropRows="True"
                       RowDragStarted="DragDrop_RowDragStarted"
-                      RowDragOver="DragDrop_RowDragOver"/>
+                      RowDragOver="DragDrop_RowDragOver"
+                      PointerPressed="DragDrop_OnPointerPressed"/>
       </DockPanel>
     </TabItem>
   </TabControl>

--- a/samples/TreeDataGridDemo/MainWindow.axaml.cs
+++ b/samples/TreeDataGridDemo/MainWindow.axaml.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
@@ -127,6 +128,17 @@ namespace TreeDataGridDemo
             var realizedRowCount = rows.GetRealizedElements().Count();
             var unrealizedRowCount = rows.GetVisualChildren().Count() - realizedRowCount;
             textBlock.Text = $"{realizedRowCount} rows realized ({unrealizedRowCount} unrealized)";
+        }
+
+        private void DragDrop_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.ClickCount != 2)
+                return;
+
+            var row = (e.Source as Control)?.FindAncestorOfType<TreeDataGridRow>();
+
+            if (row?.DataContext is DragDropItem item)
+                item.IsExpanded = !item.IsExpanded;
         }
     }
 }

--- a/samples/TreeDataGridDemo/Models/DragDropItem.cs
+++ b/samples/TreeDataGridDemo/Models/DragDropItem.cs
@@ -11,6 +11,7 @@ namespace TreeDataGridDemo.Models
         private ObservableCollection<DragDropItem>? _children;
         private bool _allowDrag = true;
         private bool _allowDrop = true;
+        private bool _isExpanded;
 
         public DragDropItem(string name) => Name = name;
         public string Name { get; }
@@ -25,6 +26,12 @@ namespace TreeDataGridDemo.Models
         {
             get => _allowDrop;
             set => this.RaiseAndSetIfChanged(ref _allowDrop, value);
+        }
+
+        public bool IsExpanded
+        {
+            get => _isExpanded;
+            set => this.RaiseAndSetIfChanged(ref _isExpanded, value);
         }
 
         public ObservableCollection<DragDropItem> Children => _children ??= CreateRandomItems();

--- a/samples/TreeDataGridDemo/ViewModels/DragDropPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/DragDropPageViewModel.cs
@@ -22,7 +22,9 @@ namespace TreeDataGridDemo.ViewModels
                             "Name",
                             x => x.Name,
                             GridLength.Star),
-                        x => x.Children),
+                        x => x.Children,
+                        x => x.Children.Count > 0,
+                        x => x.IsExpanded),
                     new CheckBoxColumn<DragDropItem>(
                         "Allow Drag",
                         x => x.AllowDrag,

--- a/src/Avalonia.Controls.TreeDataGrid/Experimental/Data/Core/TypedBindingExpression`2.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Experimental/Data/Core/TypedBindingExpression`2.cs
@@ -310,15 +310,7 @@ namespace Avalonia.Experimental.Data.Core
         {
             if (sender is null)
                 return;
-
-            var index = ChainIndexOf(sender);
-
-            if (index != -1)
-            {
-                StopListeningToChain(index);
-                ListenToChain(index);
-            }
-
+            
             PublishValue();
         }
 


### PR DESCRIPTION
This fix resolves this issue:
https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/issues/196

I removed two calls to `StopListeningToChain` and `ListenToChain` methods during process of publishing current value from VM to View layer and it works. Please take a look carefully because I'm not sure if I made some mistake. By the way, these two calls seem to be redundant during evaluation of binding value