### PR TITLE
Constrain estimated viewport.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -591,7 +591,9 @@ namespace Avalonia.Controls.Primitives
             {
                 if (!c.Bounds.Equals(default) && c.TransformToVisual(this) is Matrix transform)
                 {
-                    return new Rect(0, 0, c.Bounds.Width, c.Bounds.Height).TransformToAABB(transform);
+                    return new Rect(0, 0, c.Bounds.Width, c.Bounds.Height)
+                        .TransformToAABB(transform)
+                        .Intersect(new(0, 0, double.PositiveInfinity, double.PositiveInfinity));
                 }
 
                 c = c?.GetVisualParent();


### PR DESCRIPTION
Our layout code does not expect a viewport with a negative origin. Ensure that `EstimateViewport` doesn't return one.