### PR TITLE
Fix a couple of row issues

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/RealizedStackElements.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/RealizedStackElements.cs
@@ -286,7 +286,7 @@ namespace Avalonia.Controls.Primitives
                 for (var i = start; i < elementCount; ++i)
                 {
                     if (_elements[i] is Control element)
-                        updateElementIndex(element, newIndex - count, newIndex);
+                        updateElementIndex(element, (newIndex - count) + first, newIndex + first);
                     ++newIndex;
                 }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -45,8 +45,8 @@ namespace Avalonia.Controls.Primitives
         private RealizedStackElements? _realizedElements;
         private ScrollViewer? _scrollViewer;
         private double _lastEstimatedElementSizeU = 25;
-        private Control? _unrealizedFocusedElement;
-        private int _unrealizedFocusedIndex = -1;
+        private Control? _focusedElement;
+        private int _focusedIndex = -1;
 
         public TreeDataGridPresenterBase()
         {
@@ -542,15 +542,34 @@ namespace Avalonia.Controls.Primitives
 
         private Control GetOrCreateElement(IReadOnlyList<TItem> items, int index)
         {
-            var e = GetRealizedElement(index) ?? GetRecycledOrCreateElement(items, index);
+            var e = GetRealizedElement(index) ??
+                GetRealizedElement(index, ref _focusedIndex, ref _focusedElement) ??
+                GetRealizedElement(index, ref _scrollToIndex, ref _scrollToElement) ??
+                GetRecycledOrCreateElement(items, index);
             return e;
         }
 
         private Control? GetRealizedElement(int index)
         {
-            if (_scrollToIndex == index)
-                return _scrollToElement;
             return _realizedElements?.GetElement(index);
+        }
+
+        private static Control? GetRealizedElement(
+            int index,
+            ref int specialIndex,
+            ref Control? specialElement)
+        {
+            if (specialIndex == index)
+            {
+                Debug.Assert(specialElement is not null);
+
+                var result = specialElement;
+                specialIndex = -1;
+                specialElement = null;
+                return result;
+            }
+
+            return null;
         }
 
         private Control GetRecycledOrCreateElement(IReadOnlyList<TItem> items, int index)
@@ -610,9 +629,9 @@ namespace Avalonia.Controls.Primitives
         {
             if (element.IsKeyboardFocusWithin)
             {
-                _unrealizedFocusedElement = element;
-                _unrealizedFocusedIndex = index;
-                _unrealizedFocusedElement.LostFocus += OnUnrealizedFocusedElementLostFocus;
+                _focusedElement = element;
+                _focusedIndex = index;
+                _focusedElement.LostFocus += OnUnrealizedFocusedElementLostFocus;
             }
             else
             {
@@ -677,13 +696,13 @@ namespace Avalonia.Controls.Primitives
 
         private void OnUnrealizedFocusedElementLostFocus(object? sender, RoutedEventArgs e)
         {
-            if (_unrealizedFocusedElement is null || sender != _unrealizedFocusedElement)
+            if (_focusedElement is null || sender != _focusedElement)
                 return;
 
-            _unrealizedFocusedElement.LostFocus -= OnUnrealizedFocusedElementLostFocus;
-            RecycleElement(_unrealizedFocusedElement, _unrealizedFocusedIndex);
-            _unrealizedFocusedElement = null;
-            _unrealizedFocusedIndex = -1;
+            _focusedElement.LostFocus -= OnUnrealizedFocusedElementLostFocus;
+            RecycleElement(_focusedElement, _focusedIndex);
+            _focusedElement = null;
+            _focusedIndex = -1;
         }
 
         private static bool HasInfinity(Size s) => double.IsInfinity(s.Width) || double.IsInfinity(s.Height);

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Hierarchical.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Hierarchical.cs
@@ -98,6 +98,38 @@ namespace Avalonia.Controls.TreeDataGridTests
         }
 
         [AvaloniaFact(Timeout = 10000)]
+        public void RowIndexes_Should_Be_Correct_After_Expanding_Node_While_Scrolled()
+        {
+            var (target, source) = CreateTarget();
+            var items = (IList<Model>)source.Items;
+            var children = items[0].Children![1].Children = new AvaloniaList<Model>
+            {
+                new Model { Id = -1, Title = "First" }
+            };
+
+            source.Expand(0);
+            target.Scroll!.Offset = new Vector(0, 20);
+            Layout(target);
+            
+            var rowIndexes = target.RowsPresenter!.RealizedElements
+                .OfType<TreeDataGridRow>()
+                .Select(x => x.RowIndex)
+                .ToList();
+
+            Assert.Equal(Enumerable.Range(2, 10), rowIndexes);
+
+            source.Expand(new IndexPath(0, 1));
+            Layout(target);
+
+            rowIndexes = target.RowsPresenter!.RealizedElements
+                .OfType<TreeDataGridRow>()
+                .Select(x => x.RowIndex)
+                .ToList();
+
+            Assert.Equal(Enumerable.Range(2, 10), rowIndexes);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
         public void Should_Subscribe_To_Models_For_Initial_Rows()
         {
             var (target, source) = CreateTarget();


### PR DESCRIPTION
#136 introduced a couple of issues, fixed by this PR:

- `TreeDataGridRow.RowIndex` was being incorrectly updated when rows were inserted while scrolled, causing such problems as:
  -  #205 
  - Selecting one row could cause multiple rows to be selected
- The unrealized focused element was not being considered when getting a realized element causing #200 

Fixes #200
Fixes #205