### PR TITLE
Respect `ScrollViewer.BringIntoViewOnFocusChange`.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Themes/FluentControls.axaml
+++ b/src/Avalonia.Controls.TreeDataGrid/Themes/FluentControls.axaml
@@ -44,7 +44,8 @@
                           DockPanel.Dock="Top"
                           IsVisible="{TemplateBinding ShowColumnHeaders}"
                           HorizontalScrollBarVisibility="Hidden"
-                          VerticalScrollBarVisibility="Disabled">
+                          VerticalScrollBarVisibility="Disabled"
+                          BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
               <Border x:Name="ColumnHeadersPresenterBorder">
                 <TreeDataGridColumnHeadersPresenter Name="PART_ColumnHeadersPresenter"
                                                     ElementFactory="{TemplateBinding ElementFactory}"
@@ -52,7 +53,8 @@
               </Border>
             </ScrollViewer>
             <ScrollViewer Name="PART_ScrollViewer"
-                          HorizontalScrollBarVisibility="Auto">
+                          HorizontalScrollBarVisibility="Auto"
+                          BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}">
               <TreeDataGridRowsPresenter Name="PART_RowsPresenter"
                                          Columns="{TemplateBinding Columns}"
                                          ElementFactory="{TemplateBinding ElementFactory}"


### PR DESCRIPTION
https://github.com/AvaloniaUI/Avalonia/pull/11442 introduced a new attached property: `ScrollViewer.BringIntoViewOnFocusChange`.

We need to wire that up in order for `TreeDataGrid` to respect it.