### PR TITLE
Fix nodes appearing in wrong position

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -6,7 +6,6 @@ using Avalonia.Controls.Selection;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.LogicalTree;
-using Avalonia.Platform;
 using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
@@ -53,8 +52,12 @@ namespace Avalonia.Controls.Primitives
             int columnIndex,
             int rowIndex)
         {
+            if (ColumnIndex >= 0 || RowIndex >= 0)
+                throw new InvalidOperationException("Cell is already realized.");
             if (columnIndex < 0)
                 throw new IndexOutOfRangeException("Invalid column index.");
+            if (rowIndex < 0)
+                throw new IndexOutOfRangeException("Invalid row index.");
 
             ColumnIndex = columnIndex;
             RowIndex = rowIndex;

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
@@ -129,6 +129,14 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
+        internal void UnrealizeOnRowRemoved()
+        {
+            if (RowIndex == -1)
+                throw new InvalidOperationException("Row is not realized.");
+            RowIndex = -1;
+            RecycleAllElementsOnItemRemoved();
+        }
+
         private ITreeDataGridSelectionInteraction? GetSelection()
         {
             return this.FindAncestorOfType<TreeDataGrid>()?.SelectionInteraction;

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -177,6 +177,15 @@ namespace Avalonia.Controls.Primitives
 
         internal void RecycleAllElements() => _realizedElements?.RecycleAllElements(_recycleElement);
 
+        internal void RecycleAllElementsOnItemRemoved()
+        {
+            _realizedElements?.ItemsRemoved(
+                _realizedElements.FirstIndex,
+                _realizedElements.Count,
+                _updateElementIndex, 
+                _recycleElementOnItemRemoved);
+        }
+
         protected virtual Rect ArrangeElement(int index, Control element, Rect rect)
         {
             element.Arrange(rect);
@@ -427,6 +436,11 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
+        protected virtual void UnrealizeElementOnItemRemoved(Control element)
+        {
+            UnrealizeElement(element);
+        }
+
         private void RealizeElements(
             IReadOnlyList<TItem> items,
             Size availableSize,
@@ -643,7 +657,7 @@ namespace Avalonia.Controls.Primitives
 
         private void RecycleElementOnItemRemoved(Control element)
         {
-            UnrealizeElement(element);
+            UnrealizeElementOnItemRemoved(element);
             element.IsVisible = false;
             ElementFactory!.RecycleElement(element);
         }

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -111,7 +111,7 @@ namespace Avalonia.Controls.Primitives
             {
                 // Create and measure the element to be brought into view. Store it in a field so that
                 // it can be re-used in the layout pass.
-                _scrollToElement = GetOrCreateElement(items, index);
+                var scrollToElement = _scrollToElement = GetOrCreateElement(items, index);
                 _scrollToElement.Measure(Size.Infinity);
                 _scrollToIndex = index;
 
@@ -156,7 +156,7 @@ namespace Avalonia.Controls.Primitives
                     UpdateLayout();
                 }
 
-                var result = _scrollToElement;
+                var result = scrollToElement;
                 _scrollToElement = null;
                 _scrollToIndex = -1;
                 return result;

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
@@ -106,7 +107,6 @@ namespace Avalonia.Controls.Primitives
             IsSelected = false;
             CellsPresenter?.Unrealize();
         }
-
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
             _treeDataGrid = this.FindLogicalAncestorOfType<TreeDataGrid>();
@@ -176,6 +176,15 @@ namespace Avalonia.Controls.Primitives
         {
             IsSelected = selection?.IsRowSelected(RowIndex) ?? false;
             CellsPresenter?.UpdateSelection(selection);
+        }
+
+        public void UnrealizeOnItemRemoved()
+        {
+            _treeDataGrid?.RaiseRowClearing(this, RowIndex);
+            RowIndex = -1;
+            DataContext = null;
+            IsSelected = false;
+            CellsPresenter?.UnrealizeOnRowRemoved();
         }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -51,6 +51,12 @@ namespace Avalonia.Controls.Primitives
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, ((TreeDataGridRow)element).RowIndex));
         }
 
+        protected override void UnrealizeElementOnItemRemoved(Control element)
+        {
+            ((TreeDataGridRow)element).UnrealizeOnItemRemoved();
+            ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, ((TreeDataGridRow)element).RowIndex));
+        }
+
         protected override Size ArrangeOverride(Size finalSize)
         {
             Columns?.CommitActualWidths();

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Hierarchical.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Hierarchical.cs
@@ -457,6 +457,33 @@ namespace Avalonia.Controls.TreeDataGridTests
             Assert.Equal(-1, target.RowSelection.SelectedIndex);
         }
 
+        [AvaloniaFact(Timeout = 10000)]
+        public void Should_Recycle_Focused_Cell_When_Row_Collapsed()
+        {
+            // Issue #210.
+            var (target, source) = CreateTarget();
+
+            source.Expand(new IndexPath(0));
+            Layout(target);
+
+            Assert.Equal(10, target.RowsPresenter!.RealizedElements.Count);
+            var row = Assert.IsType<TreeDataGridRow>(target.TryGetRow(1));
+            var cell = Assert.IsType<TreeDataGridExpanderCell>(row.TryGetCell(0));
+
+            Assert.Equal(1, cell.RowIndex);
+            
+            cell.Focus();
+
+            source.Collapse(new IndexPath(0));
+
+            Assert.Equal(-1, row.RowIndex);
+
+            // At this point, the cell should have been recycled and should have a row index of -1,
+            // otherwise it can may recyled in a subsequent layout pass and the cell will not
+            // be updated correctly.
+            Assert.Equal(-1, cell.RowIndex);
+        }
+
         private static (TreeDataGrid, HierarchicalTreeDataGridSource<Model>) CreateTarget(
             IEnumerable<IColumn<Model>>? columns = null,
             bool runLayout = true)


### PR DESCRIPTION
Previously, a cell with focus wasn't being recycled when the parent row was removed as `TreeDataGridPresenterBase.RecycleElement` was being called on it, which has logic to keep the focused element around. This makes no sense when the containing row has been removed, instead `RecycleElementOnItemRemoved` should be called.

Add `TreeDataGridPresenterBase.UnrealizeOnRowRemoved` (with an override in  `TreeDataGridRowsPresenter`) and make `TreeDataGridPresenterBase.RecycleElementOnItemRemoved` call it.

Fixes #210 