### PR TITLE
Always arrange row/col presenters to final size.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -359,7 +359,7 @@ namespace Avalonia.Controls.Primitives
         protected override Size ArrangeOverride(Size finalSize)
         {
             if (_realizedElements is null)
-                return default;
+                return finalSize;
 
             _isInLayout = true;
 


### PR DESCRIPTION
Even when they have no items - otherwise star columns will not be sized correctly, resulting in #209.

Fixes #209.