### PR TITLE
Don't try to recycle when no elements realized.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -179,11 +179,14 @@ namespace Avalonia.Controls.Primitives
 
         internal void RecycleAllElementsOnItemRemoved()
         {
-            _realizedElements?.ItemsRemoved(
-                _realizedElements.FirstIndex,
-                _realizedElements.Count,
-                _updateElementIndex, 
-                _recycleElementOnItemRemoved);
+            if (_realizedElements?.Count > 0)
+            {
+                _realizedElements?.ItemsRemoved(
+                    _realizedElements.FirstIndex,
+                    _realizedElements.Count,
+                    _updateElementIndex,
+                    _recycleElementOnItemRemoved);
+            }
         }
 
         protected virtual Rect ArrangeElement(int index, Control element, Rect rect)


### PR DESCRIPTION
Because in this case, `FirstIndex` will be -1 which will cause `RealizedStackElements.ItemsRemoved` to throw an `ArgumentOutOfRangeException`.