### PR TITLE
Call child realize from parent realize.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -250,7 +250,12 @@ namespace Avalonia.Controls.Primitives
             base.OnPropertyChanged(change);
         }
 
-        internal void UpdateRowIndex(int index) => RowIndex = index;
+        internal void UpdateRowIndex(int index)
+        {
+            if (RowIndex == -1)
+                throw new InvalidOperationException("Cell is not realized.");
+            RowIndex = index;
+        }
 
         internal void UpdateSelection(ITreeDataGridSelectionInteraction? selection)
         {

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
@@ -35,7 +35,7 @@ namespace Avalonia.Controls.Primitives
         {
             if (RowIndex != -1)
                 throw new InvalidOperationException("Row is already realized.");
-            UpdateRowIndex(index);
+            RowIndex = index;
             InvalidateMeasure();
         }
 
@@ -51,6 +51,9 @@ namespace Avalonia.Controls.Primitives
         {
             if (index < 0 || Rows is null || index >= Rows.Count)
                 throw new ArgumentOutOfRangeException(nameof(index));
+            if (RowIndex == -1)
+                throw new InvalidOperationException("Row is not realized.");
+
             RowIndex = index;
 
             foreach (var element in RealizedElements)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -83,8 +83,9 @@ namespace Avalonia.Controls.Primitives
             Rows = rows;
             DataContext = rows?[rowIndex].Model;
             IsSelected = selection?.IsRowSelected(rowIndex) ?? false;
-            UpdateIndex(rowIndex);
+            RowIndex = rowIndex;
             UpdateSelection(selection);
+            CellsPresenter?.Realize(rowIndex);
             _treeDataGrid?.RaiseRowPrepared(this, RowIndex);
         }
 
@@ -95,6 +96,9 @@ namespace Avalonia.Controls.Primitives
 
         public void UpdateIndex(int index)
         {
+            if (RowIndex == -1)
+                throw new InvalidOperationException("Row is not realized.");
+
             RowIndex = index;
             CellsPresenter?.UpdateRowIndex(index);
         }
@@ -107,6 +111,7 @@ namespace Avalonia.Controls.Primitives
             IsSelected = false;
             CellsPresenter?.Unrealize();
         }
+
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
             _treeDataGrid = this.FindLogicalAncestorOfType<TreeDataGrid>();


### PR DESCRIPTION
Previously we were calling e.g. `TreeDataGridCellsPresenter.UpdateRowIndex` from `TreeDataGridRow.Realize` instead of `TreeDataGridCellsPresenter.Realize`. This was causing the cells presenter to be stuck in a half-realized state. Make sure we call child `Realize` on realize and parent `UpdateRowIndex` only when updating row index. Added checks to ensure that `UpdateRowIndex`  can't be called on an unrealized row or cell.

I'm still unclear as to why this shows up only when switching tabs (on the sample app) and I've been unable to create a failing unit test for it so far, hence marking it as draft.

Fixes #218