### PR TITLE
Unregister anchor candidates on unrealize.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -655,6 +655,7 @@ namespace Avalonia.Controls.Primitives
                 UnrealizeElement(element);
                 element.IsVisible = false;
                 ElementFactory!.RecycleElement(element);
+                _scrollViewer?.UnregisterAnchorCandidate(element);
             }
         }
 
@@ -663,6 +664,7 @@ namespace Avalonia.Controls.Primitives
             UnrealizeElementOnItemRemoved(element);
             element.IsVisible = false;
             ElementFactory!.RecycleElement(element);
+            _scrollViewer?.UnregisterAnchorCandidate(element);
         }
 
         private void TrimUnrealizedChildren()


### PR DESCRIPTION
Prevents the scroll jumping when a `TreeDataGrid` is removed and re-added to the visual tree.