### PR TITLE
Inserting items makes the StartU unstable.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/RealizedStackElements.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/RealizedStackElements.cs
@@ -294,6 +294,7 @@ namespace Avalonia.Controls.Primitives
                 {
                     // The insertion point was before the first element, update the first index.
                     _firstIndex += count;
+                    _startUUnstable = true;
                 }
                 else
                 {


### PR DESCRIPTION
Fixes layout problems in a kinda complex scenario where items are inserted before doing a `BringIntoView`. Couldn't manage to write a test, but all other updates of `_firstIndex` make `_startUUnstable`: this was one missing that was an oversight.