### PR TITLE
fix: blocks row drag-and-drop if a cell is being edited

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Input;
 using Avalonia.LogicalTree;
+using Avalonia.VisualTree;
 
 namespace Avalonia.Controls.Primitives
 {
@@ -157,7 +158,8 @@ namespace Avalonia.Controls.Primitives
             if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed || 
                 e.Handled ||
                 Math.Abs(delta.X) < DragDistance && Math.Abs(delta.Y) < DragDistance ||
-                _mouseDownPosition == s_InvalidPoint)
+                _mouseDownPosition == s_InvalidPoint ||
+                (CellsPresenter?.GetVisualChildren()?.Any(x => x is TreeDataGridCell c && c.IsEditing) == true))
                 return;
 
             _mouseDownPosition = s_InvalidPoint;


### PR DESCRIPTION
Hello,

This PR is for fixing a bug (in my opinion) that selecting a cell's text with the mouse invokes row's drag-and-drop, when it shouldn't.

Before:

https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/assets/27026741/f5f98346-89fb-402a-b0f7-42c5d9f4b2b3

After:

https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/assets/27026741/fe144f83-4f09-4702-a4f0-5dab8c88f1cf


