### PR TITLE
fix: redraws columns when source changes, to avoid collapsing

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -190,6 +190,12 @@ namespace Avalonia.Controls
                         SourceProperty,
                         oldSource,
                         _source);
+                    
+                    var c = RowsPresenter?.GetVisualParent();
+                    if (c != null)
+                    {
+                        RowsPresenter?.Columns?.ViewportChanged(new Rect(0, 0, c.Bounds.Width, c.Bounds.Height));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix for issue #130 

I used a slightly modified version of the solution proposed by @FrayxRulez

Before:

https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/assets/27026741/f8964bb6-29f3-4cde-a31f-3c0947fbbd1e

After:

https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/assets/27026741/8a94a970-9392-4eda-ad07-ec0ada4b1094