### PR TITLE
refactor/fix: calling Source.Selection.Select() was not working for FlatTree

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
@@ -364,6 +365,44 @@ namespace Avalonia.Controls.Selection
             }
 
             return null;
+        }
+
+        protected internal override bool TryGetItemAt(IndexPath index, out TModel? result)
+        {
+            if (_source is FlatTreeDataGridSource<TModel> treeSource)
+            {
+                bool valid = index.Any(i => i >= treeSource.Items.Count()) == false;
+                result = valid ? treeSource.Items.ElementAt(index[0]) : null;
+                return valid;
+            }
+
+            var items = (IReadOnlyList<TModel>?)Root.ItemsView;
+            var count = index.Count;
+
+            for (var i = 0; i < count; ++i)
+            {
+                if (items is null)
+                {
+                    result = default;
+                    return false;
+                }
+
+                var j = index[i];
+
+                if (j < items.Count)
+                {
+                    if (i == count - 1)
+                    {
+                        result = items[j];
+                        return true;
+                    }
+                    else
+                        items = GetChildren(items[j]) as IReadOnlyList<TModel>;
+                }
+            }
+
+            result = default;
+            return false;
         }
 
         protected override void OnSourceCollectionChangeFinished()

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
@@ -202,36 +202,7 @@ namespace Avalonia.Controls.Selection
 
         protected internal abstract IEnumerable<T>? GetChildren(T node);
         
-        protected virtual bool TryGetItemAt(IndexPath index, out T? result)
-        {
-            var items = (IReadOnlyList<T>?)_root.ItemsView;
-            var count = index.Count;
-
-            for (var i = 0; i < count; ++i)
-            {
-                if (items is null)
-                {
-                    result = default;
-                    return false;
-                }
-
-                var j = index[i];
-
-                if (j < items.Count)
-                {
-                    if (i == count - 1)
-                    {
-                        result = items[j];
-                        return true;
-                    }
-                    else
-                        items = GetChildren(items[j]) as IReadOnlyList<T>;
-                }
-            }
-
-            result = default;
-            return false;
-        }
+        protected internal abstract bool TryGetItemAt(IndexPath index, out T? result);
 
         protected virtual void OnSourceCollectionChangeFinished()
         {

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
@@ -1596,6 +1596,14 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                     node.Children = CreateNodes(node.Id, node.TargetDepth);
                 return node.Children;
             }
+
+            protected internal override bool TryGetItemAt(IndexPath index, out Node? result)
+            {
+                var nodes = (IList<Node>)Source!;
+                bool valid = index.Any(i => i >= nodes.Count) == false;
+                result = valid ? nodes[index[0]] : null;
+                return valid;
+            }
         }
     }
 }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 Assert.Equal("Node 0-2", target.SelectedItem!.Caption);
                 Assert.Equal("Node 0-2", target.SelectedItems.Single()!.Caption);
             }
-            
+
             [AvaloniaFact(Timeout = 10000)]
             public void Can_Set_Grandchild_SelectedIndex()
             {
@@ -329,7 +329,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 Assert.Equal(1, raised);
             }
         }
-        
+
         public class Select
         {
             [AvaloniaFact(Timeout = 10000)]
@@ -1292,6 +1292,14 @@ namespace Avalonia.Controls.TreeDataGridTests
                 if (node.Children is null && node.Id.Count < node.TargetDepth)
                     node.Children = CreateNodes(node.Id, node.TargetDepth);
                 return node.Children;
+            }
+
+            protected internal override bool TryGetItemAt(IndexPath index, out Node? result)
+            {
+                var nodes = (IList<Node>)Source!;
+                bool valid = index.Any(i => i >= nodes.Count) == false;
+                result = valid ? nodes[index[0]] : null;
+                return valid;
             }
         }
     }


### PR DESCRIPTION
Calling Source.Selection.Select() was not working for FlatTree
Now it works, but only selecting one index at a time, I don't know how to select multiple using IndexPath...
Like, this works:

```cs
treeDataGrid.Source.Selection.Select(new IndexPath(1));
treeDataGrid.Source.Selection.Select(new IndexPath(2));
```

This doesn't work:


```cs
treeDataGrid.Source.Selection.Select(new IndexPath(1, 2));
```