### PR TITLE
Fix star-sized columns collapsing

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -80,6 +80,13 @@ namespace Avalonia.Controls.Primitives
                     oldValue.LayoutInvalidated -= OnColumnLayoutInvalidated;
                 if (newValue is object)
                     newValue.LayoutInvalidated += OnColumnLayoutInvalidated;
+
+                // When for existing Presenter Columns would be recreated they won't get Viewport set so we need to track that
+                // and pass Viewport for a newly created object. 
+                if (oldValue != null && newValue != null)
+                {
+                    newValue.ViewportChanged(Viewport);
+                }
             }
 
             base.OnPropertyChanged(change);


### PR DESCRIPTION
When we create an initial TreeDataGridSource ColumnList is getting created. Then we get the Viewport from the [EffectiveViewportChanged](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/blob/master/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs#L56) event and [initialize](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/blob/master/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs#L69) the ColumnList. But when user re-creates the TreeDataGridSource ColumnList is getting recreated too but Viewport is not set for this ColumnList since EffectiveViewportChanged is not called because EffectiveViewPort remained the same, so we need to pass Viewport by ourselves.

Fixes #130
Closes #231