### PR TITLE
Fix deselection for RowSelection.SingleSelect = true

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -459,7 +459,7 @@ namespace Avalonia.Controls.Selection
             else if (toggle)
             {
                 if (!treeDataGrid.QueryCancelSelection())
-                    SelectedIndex = (SelectedIndex == rowIndex) ? -1 : modelIndex;
+                    SelectedIndex = (SelectedIndex == modelIndex) ? -1 : modelIndex;
             }
             else if (SelectedIndex != modelIndex || Count > 1)
             {


### PR DESCRIPTION
Fixes #258.

I manually tested that it fixes the issue with the sample app, and that `SingleSelect = false` also still works. I wasn't able to trigger pointer event handlers to cover these changes in unit tests using `HeadlessWindowExtensions`, but if there is any example on how to use them I'd also write the tests.