### PR TITLE
Fix TreeDataGridPresenterBase Replace Regression

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -705,7 +705,15 @@ namespace Avalonia.Controls.Primitives
                     _realizedElements.ItemsRemoved(e.OldStartingIndex, e.OldItems!.Count, _updateElementIndex, _recycleElementOnItemRemoved);
                     break;
                 case NotifyCollectionChangedAction.Replace:
-                    _realizedElements.ItemsReplaced(e.OldStartingIndex, e.OldItems!.Count, _recycleElementOnItemRemoved);
+                    if (e.OldItems!.Count == e.NewItems!.Count)
+                    {
+                        _realizedElements.ItemsReplaced(e.OldStartingIndex, e.OldItems!.Count, _recycleElementOnItemRemoved);
+                    }
+                    else
+                    {
+                        _realizedElements.ItemsRemoved(e.OldStartingIndex, e.OldItems!.Count, _updateElementIndex, _recycleElementOnItemRemoved);
+                        _realizedElements.ItemsInserted(e.NewStartingIndex, e.NewItems!.Count, _updateElementIndex);
+                    }
                     break;
                 case NotifyCollectionChangedAction.Move:
                     _realizedElements.ItemsRemoved(e.OldStartingIndex, e.OldItems!.Count, _updateElementIndex, _recycleElementOnItemRemoved);


### PR DESCRIPTION
This fixes https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/issues/265. The more efficient use of `ItemsReplaced` is kept when the old and new items have the same length. Otherwise, the previous behavior is used.

Note that https://github.com/AvaloniaUI/Avalonia/pull/13795 made the same change to `VirtualizingStackPanel` that was made to `TreeDataGridPresenterBase` which caused the issue. I haven't used the `VirtualizingStackPanel` before, so I can't test if it has the same issue.