### PR TITLE
Improve performance of Equals function in IndexPath

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/IndexPath.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/IndexPath.cs
@@ -18,20 +18,20 @@ namespace Avalonia.Controls
 
         private readonly int _index;
         private readonly int[]? _path;
-        private readonly string _hashCode;
+        private readonly int _hashCode;
 
         public IndexPath(int index)
         {
             _index = index + 1;
             _path = null;
-            _hashCode = CalculateHashCode();
+            _hashCode = CalculateHashCode(_path, _index);
         }
 
         public IndexPath(params int[] indexes)
         {
             _index = 0;
             _path = indexes;
-            _hashCode = CalculateHashCode();
+            _hashCode = CalculateHashCode(_path, _index);
         }
 
         public IndexPath(IEnumerable<int>? indexes)
@@ -47,7 +47,7 @@ namespace Avalonia.Controls
                 _path = null;
             }
 
-            _hashCode = CalculateHashCode();
+            _hashCode = CalculateHashCode(_path, _index);
         }
 
         private IndexPath(int[] basePath, int index)
@@ -59,7 +59,7 @@ namespace Avalonia.Controls
             Array.Copy(basePath, _path, basePath.Length);
             _path[basePath.Length] = index;
 
-            _hashCode = CalculateHashCode();
+            _hashCode = CalculateHashCode(_path, _index);
         }
 
         public int Count => _path?.Length ?? (_index == 0 ? 0 : 1);
@@ -159,18 +159,18 @@ namespace Avalonia.Controls
             return _hashCode;
         }
 
-        public override int CalculateHashCode()
+        public static int CalculateHashCode(int[]? path, int index)
         {
             var hashCode = -504981047;
 
-            if (_path != null)
+            if (path != null)
             {
-                foreach (var i in _path)
+                foreach (var i in path)
                     hashCode = hashCode * -1521134295 + i.GetHashCode();
             }
             else
             {
-                hashCode = hashCode * -1521134295 + _index.GetHashCode();
+                hashCode = hashCode * -1521134295 + index.GetHashCode();
             }
 
             return hashCode;

--- a/src/Avalonia.Controls.TreeDataGrid/IndexPath.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/IndexPath.cs
@@ -18,17 +18,20 @@ namespace Avalonia.Controls
 
         private readonly int _index;
         private readonly int[]? _path;
+        private readonly string _hashCode;
 
         public IndexPath(int index)
         {
             _index = index + 1;
             _path = null;
+            _hashCode = CalculateHashCode();
         }
 
         public IndexPath(params int[] indexes)
         {
             _index = 0;
             _path = indexes;
+            _hashCode = CalculateHashCode();
         }
 
         public IndexPath(IEnumerable<int>? indexes)
@@ -43,6 +46,8 @@ namespace Avalonia.Controls
                 _index = 0;
                 _path = null;
             }
+
+            _hashCode = CalculateHashCode();
         }
 
         private IndexPath(int[] basePath, int index)
@@ -53,6 +58,8 @@ namespace Avalonia.Controls
             _path = new int[basePath.Length + 1];
             Array.Copy(basePath, _path, basePath.Length);
             _path[basePath.Length] = index;
+
+            _hashCode = CalculateHashCode();
         }
 
         public int Count => _path?.Length ?? (_index == 0 ? 0 : 1);
@@ -69,6 +76,9 @@ namespace Avalonia.Controls
 
         public int CompareTo(IndexPath other)
         {
+            if (_hashCode == other._hashCode)
+                return 0;
+
             var rhsPath = other;
             var compareResult = 0;
             var lhsCount = Count;
@@ -131,7 +141,7 @@ namespace Avalonia.Controls
 
         public override bool Equals(object? obj) => obj is IndexPath other && Equals(other);
 
-        public bool Equals(IndexPath other) => CompareTo(other) == 0;
+        public bool Equals(IndexPath other) => _hashCode == other._hashCode;
 
         public IEnumerator<int> GetEnumerator()
         {
@@ -145,6 +155,11 @@ namespace Avalonia.Controls
         }
 
         public override int GetHashCode()
+        {
+            return _hashCode;
+        }
+
+        public override int CalculateHashCode()
         {
             var hashCode = -504981047;
 
@@ -233,9 +248,9 @@ namespace Avalonia.Controls
         public static bool operator >(IndexPath x, IndexPath y) => x.CompareTo(y) > 0;
         public static bool operator <=(IndexPath x, IndexPath y) => x.CompareTo(y) <= 0;
         public static bool operator >=(IndexPath x, IndexPath y) => x.CompareTo(y) >= 0;
-        public static bool operator ==(IndexPath x, IndexPath y) => x.CompareTo(y) == 0;
-        public static bool operator !=(IndexPath x, IndexPath y) => x.CompareTo(y) != 0;
-        public static bool operator ==(IndexPath? x, IndexPath? y) => (x ?? default).CompareTo(y ?? default) == 0;
-        public static bool operator !=(IndexPath? x, IndexPath? y) => (x ?? default).CompareTo(y ?? default) != 0;
+        public static bool operator ==(IndexPath x, IndexPath y) => x._hashCode == y._hashCode;
+        public static bool operator !=(IndexPath x, IndexPath y) => x._hashCode != y._hashCode;
+        public static bool operator ==(IndexPath? x, IndexPath? y) => (x ?? default)._hashCode == (y ?? default)._hashCode;
+        public static bool operator !=(IndexPath? x, IndexPath? y) => (x ?? default)._hashCode != (y ?? default)._hashCode;
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/IndexPath.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/IndexPath.cs
@@ -76,7 +76,7 @@ namespace Avalonia.Controls
 
         public int CompareTo(IndexPath other)
         {
-            if (_hashCode == other._hashCode)
+            if (GetHashCode() == other.GetHashCode())
                 return 0;
 
             var rhsPath = other;
@@ -141,7 +141,7 @@ namespace Avalonia.Controls
 
         public override bool Equals(object? obj) => obj is IndexPath other && Equals(other);
 
-        public bool Equals(IndexPath other) => _hashCode == other._hashCode;
+        public bool Equals(IndexPath other) => GetHashCode() == other.GetHashCode();
 
         public IEnumerator<int> GetEnumerator()
         {
@@ -156,10 +156,10 @@ namespace Avalonia.Controls
 
         public override int GetHashCode()
         {
-            return _hashCode;
+            return _hashCode == 0 ? CalculateHashCode(_path, _index) : _hashCode;
         }
 
-        public static int CalculateHashCode(int[]? path, int index)
+        private static int CalculateHashCode(int[]? path, int index)
         {
             var hashCode = -504981047;
 
@@ -170,7 +170,7 @@ namespace Avalonia.Controls
             }
             else
             {
-                hashCode = hashCode * -1521134295 + index.GetHashCode();
+                hashCode = hashCode * -1521134295 + (index - 1).GetHashCode();
             }
 
             return hashCode;
@@ -248,9 +248,9 @@ namespace Avalonia.Controls
         public static bool operator >(IndexPath x, IndexPath y) => x.CompareTo(y) > 0;
         public static bool operator <=(IndexPath x, IndexPath y) => x.CompareTo(y) <= 0;
         public static bool operator >=(IndexPath x, IndexPath y) => x.CompareTo(y) >= 0;
-        public static bool operator ==(IndexPath x, IndexPath y) => x._hashCode == y._hashCode;
-        public static bool operator !=(IndexPath x, IndexPath y) => x._hashCode != y._hashCode;
-        public static bool operator ==(IndexPath? x, IndexPath? y) => (x ?? default)._hashCode == (y ?? default)._hashCode;
-        public static bool operator !=(IndexPath? x, IndexPath? y) => (x ?? default)._hashCode != (y ?? default)._hashCode;
+        public static bool operator ==(IndexPath x, IndexPath y) => x.GetHashCode() == y.GetHashCode();
+        public static bool operator !=(IndexPath x, IndexPath y) => x.GetHashCode() != y.GetHashCode();
+        public static bool operator ==(IndexPath? x, IndexPath? y) => (x ?? default).GetHashCode() == (y ?? default).GetHashCode();
+        public static bool operator !=(IndexPath? x, IndexPath? y) => (x ?? default).GetHashCode() != (y ?? default).GetHashCode();
     }
 }


### PR DESCRIPTION
### What does the pull request do?
Improves the performance of the `Equals` function, as well as the `==` and `!=` operations, by pre-calculating the hash code in the constructor and using it to compare the objects.

### What is the current behavior?
When two `IndexPath` objects are compared for equality, the `CompareTo` method is executed, which can be too slow when comparing a large number of `IndexPaths`
The `IndexPaths` comparison is a limitation when trying to expand all nodes in a large tree, because it is a very heavily used operation used to convert model indexes to row indexes.

### What is the updated/expected behavior with this PR?
In every constructor of the `IndexPath` we calculate the hash code and store it in a member. Then this member is used whenever we need to compare two `IndexPath` objects for equality, which is much faster than using the `CompareTo` method.