### PR TITLE
Add methods to expand/collapse multiple levels of items without a performance penalty.

### DIFF
--- a/Avalonia.Controls.TreeDataGrid.v3.ncrunchsolution
+++ b/Avalonia.Controls.TreeDataGrid.v3.ncrunchsolution
@@ -1,6 +1,8 @@
 ﻿<SolutionConfiguration>
   <Settings>
     <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <EnableRDI>False</EnableRDI>
+    <RdiConfigured>True</RdiConfigured>
     <SolutionConfigured>True</SolutionConfigured>
   </Settings>
 </SolutionConfiguration>

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -105,6 +105,7 @@ namespace Avalonia.Controls
         }
 
         public void Collapse(IndexPath index) => GetOrCreateRows().Collapse(index);
+        public void CollapseAll() => GetOrCreateRows().CollapseAll();
         public void Expand(IndexPath index) => GetOrCreateRows().Expand(index);
         public void ExpandAll() => GetOrCreateRows().ExpandRecursive(null);
         public void ExpandRecursive(Func<TModel, bool> filter) => GetOrCreateRows().ExpandRecursive(filter);

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -104,12 +104,54 @@ namespace Avalonia.Controls
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Collapses the row at the specified index.
+        /// </summary>
+        /// <param name="index">The index path of the row to collapse.</param>
         public void Collapse(IndexPath index) => GetOrCreateRows().Collapse(index);
-        public void CollapseAll() => GetOrCreateRows().CollapseAll();
+
+        /// <summary>
+        /// Collapses all rows.
+        /// </summary>
+        public void CollapseAll() => GetOrCreateRows().ExpandCollapseRecursive(_ => false);
+
+        /// <summary>
+        /// Expands the row at the specified index.
+        /// </summary>
+        /// <param name="index">The index path of the row to expand.</param>
         public void Expand(IndexPath index) => GetOrCreateRows().Expand(index);
-        public void ExpandAll() => GetOrCreateRows().ExpandRecursive(null);
-        public void ExpandRecursive(Func<TModel, bool> filter) => GetOrCreateRows().ExpandRecursive(filter);
-        public void ExpandRecursive(HierarchicalRow<TModel> row, Func<TModel, bool> filter) => GetOrCreateRows().ExpandRecursive(row, filter);
+
+        /// <summary>
+        /// Expands all rows.
+        /// </summary>
+        public void ExpandAll() => GetOrCreateRows().ExpandCollapseRecursive(_ => true);
+
+        /// <summary>
+        /// Expands or collapses rows according to a condition.
+        /// </summary>
+        /// <param name="predicate">
+        /// A function which is passed a model instance and returns a boolean value representing
+        /// the desired expanded state of the row.
+        /// </param>
+        public void ExpandCollapseRecursive(Func<TModel, bool> predicate)
+        {
+            GetOrCreateRows().ExpandCollapseRecursive(predicate);
+        }
+
+        /// <summary>
+        /// Expands or collapses rows according to a condition, starting from the specified row.
+        /// </summary>
+        /// <param name="row">
+        /// The row from which to start expanding or collapsing.
+        /// </param>
+        /// <param name="predicate">
+        /// A function which is passed a model instance and returns a boolean value representing
+        /// the desired expanded state of the row.
+        /// </param>
+        public void ExpandCollapseRecursive(HierarchicalRow<TModel> row, Func<TModel, bool> predicate)
+        {
+            GetOrCreateRows().ExpandCollapseRecursive(predicate, row);
+        }
 
         public bool TryGetModelAt(IndexPath index, [NotNullWhen(true)] out TModel? result)
         {

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -104,8 +104,10 @@ namespace Avalonia.Controls
             GC.SuppressFinalize(this);
         }
 
-        public void Expand(IndexPath index) => GetOrCreateRows().Expand(index);
         public void Collapse(IndexPath index) => GetOrCreateRows().Collapse(index);
+        public void Expand(IndexPath index) => GetOrCreateRows().Expand(index);
+        public void ExpandAll() => GetOrCreateRows().ExpandRecursive(null);
+        public void ExpandRecursive(Func<TModel, bool> filter) => GetOrCreateRows().ExpandRecursive(filter);
 
         public bool TryGetModelAt(IndexPath index, [NotNullWhen(true)] out TModel? result)
         {

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -109,6 +109,7 @@ namespace Avalonia.Controls
         public void Expand(IndexPath index) => GetOrCreateRows().Expand(index);
         public void ExpandAll() => GetOrCreateRows().ExpandRecursive(null);
         public void ExpandRecursive(Func<TModel, bool> filter) => GetOrCreateRows().ExpandRecursive(filter);
+        public void ExpandRecursive(HierarchicalRow<TModel> row, Func<TModel, bool> filter) => GetOrCreateRows().ExpandRecursive(row, filter);
 
         public bool TryGetModelAt(IndexPath index, [NotNullWhen(true)] out TModel? result)
         {

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -131,6 +131,31 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             }
         }
 
+        internal void CollapseAll()
+        {
+            static void Collapse(IReadOnlyList<HierarchicalRow<TModel>> rows)
+            {
+                for (var i = 0; i < rows.Count; ++i)
+                {
+                    var row = rows[i];
+
+                    if (row.Children is { } children)
+                        Collapse(children);
+
+                    row.IsExpanded = false;
+                }
+            }
+
+            _ignoreCollectionChanges = true;
+
+            try { Collapse(_roots); }
+            finally { _ignoreCollectionChanges = false; }
+
+            _flattenedRows.Clear();
+            InitializeRows();
+            CollectionChanged?.Invoke(this, CollectionExtensions.ResetEvent);
+        }
+
         public (int index, double y) GetRowAt(double y)
         {
             if (MathUtilities.IsZero(y))

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -40,6 +40,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
         public void Dispose()
         {
+            _ignoreCollectionChanges = true;
             _roots.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/SortableRowsBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/SortableRowsBase.cs
@@ -35,6 +35,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         {
             get
             {
+                GetOrCreateRows();
+
                 if (_sortedIndexes is null)
                     return UnsortedRows[index];
                 else

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -454,6 +454,19 @@ namespace Avalonia.Controls.TreeDataGridTests
                 Assert.False(expander.ShowExpander);
                 Assert.False(expander.IsExpanded);
             }
+
+            [AvaloniaTheory(Timeout = 10000)]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ExpandAll_Expands_All_Rows(bool sorted)
+            {
+                var data = CreateData(5, 3, 3);
+                var target = CreateTarget(data, sorted);
+
+                target.ExpandAll();
+
+                Assert.Equal(65, target.Rows.Count);
+            }
         }
 
         public class ExpansionBinding
@@ -856,6 +869,35 @@ namespace Avalonia.Controls.TreeDataGridTests
                 }
             }
 
+            return result;
+        }
+
+        private static AvaloniaListDebug<Node> CreateData(params int[] counts)
+        {
+            var id = 0;
+
+            void Create(int[] counts, int index, IList<Node> result)
+            {
+                var count = counts[index];
+
+                for (var i = 0; i < count; ++i)
+                {
+                    var node = new Node
+                    {
+                        Id = id++,
+                        Caption = $"Node {i}",
+                        Children = new AvaloniaListDebug<Node>(),
+                    };
+
+                    if (index < counts.Length - 1)
+                        Create(counts, index + 1, node.Children!);
+
+                    result.Add(node);
+                }
+            }
+
+            var result = new AvaloniaListDebug<Node>();
+            Create(counts, 0, result);
             return result;
         }
 

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -727,24 +727,20 @@ namespace Avalonia.Controls.TreeDataGridTests
             {
                 var data = CreateData();
                 var target = CreateTarget(data, sorted);
-                var rowsAddedRaised = 0;
-                var rowsRemovedRaised = 0;
+                var raised = 0;
 
                 Assert.Equal(5, target.Rows.Count);
 
                 target.Rows.CollectionChanged += (s, e) =>
                 {
-                    if (e.Action == NotifyCollectionChangedAction.Add)
-                        rowsAddedRaised += e.NewItems!.Count;
-                    else if (e.Action == NotifyCollectionChangedAction.Remove)
-                        rowsRemovedRaised += e.OldItems!.Count;
+                    Assert.Equal(NotifyCollectionChangedAction.Reset, e.Action);
+                    ++raised;
                 };
 
                 target.Items = CreateData(10);
 
                 Assert.Equal(10, target.Rows.Count);
-                Assert.Equal(5, rowsRemovedRaised);
-                Assert.Equal(10, rowsAddedRaised);
+                Assert.Equal(1, raised);
             }
 
             [AvaloniaTheory(Timeout = 10000)]
@@ -754,25 +750,21 @@ namespace Avalonia.Controls.TreeDataGridTests
             {
                 var data = CreateData();
                 var target = CreateTarget(data, sorted);
-                var rowsAddedRaised = 0;
-                var rowsRemovedRaised = 0;
+                var raised = 0;
 
                 target.Expand(0);
                 Assert.Equal(10, target.Rows.Count);
 
                 target.Rows.CollectionChanged += (s, e) =>
                 {
-                    if (e.Action == NotifyCollectionChangedAction.Add)
-                        rowsAddedRaised += e.NewItems!.Count;
-                    else if (e.Action == NotifyCollectionChangedAction.Remove)
-                        rowsRemovedRaised += e.OldItems!.Count;
+                    Assert.Equal(NotifyCollectionChangedAction.Reset, e.Action);
+                    ++raised;
                 };
 
                 target.Items = CreateData(12);
 
                 Assert.Equal(12, target.Rows.Count);
-                Assert.Equal(10, rowsRemovedRaised);
-                Assert.Equal(12, rowsAddedRaised);
+                Assert.Equal(1, raised);
             }
 
             [AvaloniaTheory(Timeout = 10000)]

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -467,6 +467,28 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 Assert.Equal(65, target.Rows.Count);
             }
+
+            [AvaloniaTheory(Timeout = 10000)]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CollapseAll_Collapses_All_Rows(bool sorted)
+            {
+                var data = CreateData(5, 3, 3);
+                var target = CreateTarget(data, sorted);
+
+                // We need to expand before we can collapse.
+                target.ExpandAll();
+                Assert.Equal(65, target.Rows.Count);
+
+                // Now we can test collapsing.
+                target.CollapseAll();
+                Assert.Equal(5, target.Rows.Count);
+
+                // Ensure that nested rows were collapsed, i.e. only the first level of rows is
+                // visible after expanding now.
+                target.Expand(0);
+                Assert.Equal(8, target.Rows.Count);
+            }
         }
 
         public class ExpansionBinding


### PR DESCRIPTION
Previously the only way to e.g. expand all items in a hierarchical `TreeDataGrid` was to expand each item one by one. This was very slow as after each expansion the flattened list of rows needed to be recalculated.

Added the follow methods which speed this up:

- `ExpandAll`: to expand all rows recursively
- `ExpandCollapseRecursive`: to expand or collapse all rows recursively based on a predicate
- `CollapseAll`: to collapse all rows recursively
