### PR TITLE
Propagate the `isExpanded` value for all children in the hierarchy

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -105,6 +105,7 @@ namespace Avalonia.Controls
         }
 
         public void Collapse(IndexPath index) => GetOrCreateRows().Collapse(index);
+        public void CollapseAll() => GetOrCreateRows().CollapseAll();
         public void Expand(IndexPath index) => GetOrCreateRows().Expand(index);
         public void ExpandAll() => GetOrCreateRows().ExpandRecursive(null);
         public void ExpandRecursive(Func<TModel, bool> filter) => GetOrCreateRows().ExpandRecursive(filter);

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -104,8 +104,10 @@ namespace Avalonia.Controls
             GC.SuppressFinalize(this);
         }
 
-        public void Expand(IndexPath index) => GetOrCreateRows().Expand(index);
         public void Collapse(IndexPath index) => GetOrCreateRows().Collapse(index);
+        public void Expand(IndexPath index) => GetOrCreateRows().Expand(index);
+        public void ExpandAll() => GetOrCreateRows().ExpandRecursive(null);
+        public void ExpandRecursive(Func<TModel, bool> filter) => GetOrCreateRows().ExpandRecursive(filter);
 
         public bool TryGetModelAt(IndexPath index, [NotNullWhen(true)] out TModel? result)
         {

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
@@ -40,6 +40,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         }
 
         /// <summary>
+        /// Gets the row's child rows.
+        /// </summary>
+        public IReadOnlyList<HierarchicalRow<TModel>>? AllChildRows => _childRows;
+
+        /// <summary>
         /// Gets the row's visible child rows.
         /// </summary>
         public IReadOnlyList<HierarchicalRow<TModel>>? VisibleChildren => _isExpanded ? _childRows : null;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
@@ -42,7 +42,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// <summary>
         /// Gets the row's visible child rows.
         /// </summary>
-        public IReadOnlyList<HierarchicalRow<TModel>>? Children => _isExpanded ? _childRows : null;
+        public IReadOnlyList<HierarchicalRow<TModel>>? VisibleChildren => _isExpanded ? _childRows : null;
 
         /// <summary>
         /// Gets the index of the model relative to its parent.

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRow.cs
@@ -137,17 +137,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             }
         }
 
-        private void Expand()
+        internal void CreateChildRows()
         {
-            if (!_expanderColumn.HasChildren(Model))
-            {
-                _expanderColumn.SetModelIsExpanded(this);
-                return;
-            }
-
-            _controller.OnBeginExpandCollapse(this);
-
-            var oldExpanded = _isExpanded;
             var childModels = _expanderColumn.GetChildModels(Model);
 
             if (_childModels != childModels)
@@ -159,6 +150,21 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                     TreeDataGridItemsSourceView<TModel>.GetOrCreate(childModels),
                     _comparison);
             }
+        }
+
+        private void Expand()
+        {
+            if (!_expanderColumn.HasChildren(Model))
+            {
+                _expanderColumn.SetModelIsExpanded(this);
+                return;
+            }
+
+            _controller.OnBeginExpandCollapse(this);
+
+            var oldExpanded = _isExpanded;
+
+            CreateChildRows();
 
             if (_childRows?.Count > 0)
                 _isExpanded = true;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -63,7 +63,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                     if (row.ModelIndex == modelIndex)
                     {
                         row.IsExpanded = true;
-                        rows = row.Children;
+                        rows = row.VisibleChildren;
                         found = true;
                         break;
                     }
@@ -85,7 +85,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                     if (filter is null || filter(row.Model))
                     {
                         row.IsExpanded = true;
-                        if (row.Children is { } children)
+                        if (row.VisibleChildren is { } children)
                             Expand(children, filter);
                     }
                 }
@@ -120,7 +120,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                     {
                         if (i == count - 1)
                             row.IsExpanded = false;
-                        rows = row.Children;
+                        rows = row.VisibleChildren;
                         found = true;
                         break;
                     }
@@ -139,7 +139,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                 {
                     var row = rows[i];
 
-                    if (row.Children is { } children)
+                    if (row.VisibleChildren is { } children)
                         Collapse(children);
 
                     row.IsExpanded = false;
@@ -292,9 +292,9 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             var i = index;
             _flattenedRows.Insert(i++, row);
 
-            if (row.Children is object)
+            if (row.VisibleChildren is object)
             {
-                foreach (var childRow in row.Children)
+                foreach (var childRow in row.VisibleChildren)
                 {
                     i += AddRowsAndDescendants(i, childRow);
                 }
@@ -366,8 +366,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                 while (count > 0)
                 {
                     var row = _flattenedRows[i];
-                    if (row.Children?.Count > 0)
-                        i = Advance(i + 1, row.Children.Count);
+                    if (row.VisibleChildren?.Count > 0)
+                        i = Advance(i + 1, row.VisibleChildren.Count);
                     else
                         i += + 1;
                     --count;
@@ -430,7 +430,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                 case NotifyCollectionChangedAction.Reset:
                     if (TryGetRowIndex(parentIndex, out parentRowIndex))
                     {
-                        var children = parentRowIndex >= 0 ? _flattenedRows[parentRowIndex].Children : _roots;
+                        var children = parentRowIndex >= 0 ? _flattenedRows[parentRowIndex].VisibleChildren : _roots;
                         var count = GetDescendentRowCount(parentRowIndex);
                         Remove(parentRowIndex + 1, count, true);
                         Add(parentRowIndex + 1, children, true);

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         {
             static void Expand(IReadOnlyList<HierarchicalRow<TModel>> rows, Func<TModel, bool>? filter)
             {
-                for (var i = 0; i < rows.Count; ++i)
+                for (int i=0; i < rows.Count; i++)
                 {
                     var row = rows[i];
 
@@ -86,6 +86,12 @@ namespace Avalonia.Controls.Models.TreeDataGrid
                     {
                         row.IsExpanded = true;
                         if (row.VisibleChildren is { } children)
+                            Expand(children, filter);
+                    }
+                    else
+                    {
+                        row.CreateChildRows();
+                        if (row.AllChildRows is { } children)
                             Expand(children, filter);
                     }
                 }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -78,7 +78,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         {
             static void Expand(IReadOnlyList<HierarchicalRow<TModel>> rows, Func<TModel, bool>? filter)
             {
-                for (int i=0; i < rows.Count; i++)
+                for (int i = 0; i < rows.Count; i++)
                 {
                     var row = rows[i];
 

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -131,6 +131,31 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             }
         }
 
+        internal void CollapseAll()
+        {
+            static void Collapse(IReadOnlyList<HierarchicalRow<TModel>> rows)
+            {
+                for (var i = 0; i < rows.Count; ++i)
+                {
+                    var row = rows[i];
+
+                    if (row.Children is { } children)
+                        Collapse(children);
+
+                    row.IsExpanded = false;
+                }
+            }
+
+            _ignoreCollectionChanges = true;
+
+            try { Collapse(_roots); }
+            finally { _ignoreCollectionChanges = false; }
+
+            _flattenedRows.Clear();
+            InitializeRows();
+            CollectionChanged?.Invoke(this, CollectionExtensions.ResetEvent);
+        }
+
         public (int index, double y) GetRowAt(double y)
         {
             if (MathUtilities.IsZero(y))

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/HierarchicalRows.cs
@@ -40,6 +40,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
         public void Dispose()
         {
+            _ignoreCollectionChanges = true;
             _roots.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/SortableRowsBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/SortableRowsBase.cs
@@ -35,6 +35,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         {
             get
             {
+                GetOrCreateRows();
+
                 if (_sortedIndexes is null)
                     return UnsortedRows[index];
                 else

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -454,6 +454,19 @@ namespace Avalonia.Controls.TreeDataGridTests
                 Assert.False(expander.ShowExpander);
                 Assert.False(expander.IsExpanded);
             }
+
+            [AvaloniaTheory(Timeout = 10000)]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void ExpandAll_Expands_All_Rows(bool sorted)
+            {
+                var data = CreateData(5, 3, 3);
+                var target = CreateTarget(data, sorted);
+
+                target.ExpandAll();
+
+                Assert.Equal(65, target.Rows.Count);
+            }
         }
 
         public class ExpansionBinding
@@ -856,6 +869,35 @@ namespace Avalonia.Controls.TreeDataGridTests
                 }
             }
 
+            return result;
+        }
+
+        private static AvaloniaListDebug<Node> CreateData(params int[] counts)
+        {
+            var id = 0;
+
+            void Create(int[] counts, int index, IList<Node> result)
+            {
+                var count = counts[index];
+
+                for (var i = 0; i < count; ++i)
+                {
+                    var node = new Node
+                    {
+                        Id = id++,
+                        Caption = $"Node {i}",
+                        Children = new AvaloniaListDebug<Node>(),
+                    };
+
+                    if (index < counts.Length - 1)
+                        Create(counts, index + 1, node.Children!);
+
+                    result.Add(node);
+                }
+            }
+
+            var result = new AvaloniaListDebug<Node>();
+            Create(counts, 0, result);
             return result;
         }
 

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -727,24 +727,20 @@ namespace Avalonia.Controls.TreeDataGridTests
             {
                 var data = CreateData();
                 var target = CreateTarget(data, sorted);
-                var rowsAddedRaised = 0;
-                var rowsRemovedRaised = 0;
+                var raised = 0;
 
                 Assert.Equal(5, target.Rows.Count);
 
                 target.Rows.CollectionChanged += (s, e) =>
                 {
-                    if (e.Action == NotifyCollectionChangedAction.Add)
-                        rowsAddedRaised += e.NewItems!.Count;
-                    else if (e.Action == NotifyCollectionChangedAction.Remove)
-                        rowsRemovedRaised += e.OldItems!.Count;
+                    Assert.Equal(NotifyCollectionChangedAction.Reset, e.Action);
+                    ++raised;
                 };
 
                 target.Items = CreateData(10);
 
                 Assert.Equal(10, target.Rows.Count);
-                Assert.Equal(5, rowsRemovedRaised);
-                Assert.Equal(10, rowsAddedRaised);
+                Assert.Equal(1, raised);
             }
 
             [AvaloniaTheory(Timeout = 10000)]
@@ -754,25 +750,21 @@ namespace Avalonia.Controls.TreeDataGridTests
             {
                 var data = CreateData();
                 var target = CreateTarget(data, sorted);
-                var rowsAddedRaised = 0;
-                var rowsRemovedRaised = 0;
+                var raised = 0;
 
                 target.Expand(0);
                 Assert.Equal(10, target.Rows.Count);
 
                 target.Rows.CollectionChanged += (s, e) =>
                 {
-                    if (e.Action == NotifyCollectionChangedAction.Add)
-                        rowsAddedRaised += e.NewItems!.Count;
-                    else if (e.Action == NotifyCollectionChangedAction.Remove)
-                        rowsRemovedRaised += e.OldItems!.Count;
+                    Assert.Equal(NotifyCollectionChangedAction.Reset, e.Action);
+                    ++raised;
                 };
 
                 target.Items = CreateData(12);
 
                 Assert.Equal(12, target.Rows.Count);
-                Assert.Equal(10, rowsRemovedRaised);
-                Assert.Equal(12, rowsAddedRaised);
+                Assert.Equal(1, raised);
             }
 
             [AvaloniaTheory(Timeout = 10000)]

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -467,6 +467,28 @@ namespace Avalonia.Controls.TreeDataGridTests
 
                 Assert.Equal(65, target.Rows.Count);
             }
+
+            [AvaloniaTheory(Timeout = 10000)]
+            [InlineData(false)]
+            [InlineData(true)]
+            public void CollapseAll_Collapses_All_Rows(bool sorted)
+            {
+                var data = CreateData(5, 3, 3);
+                var target = CreateTarget(data, sorted);
+
+                // We need to expand before we can collapse.
+                target.ExpandAll();
+                Assert.Equal(65, target.Rows.Count);
+
+                // Now we can test collapsing.
+                target.CollapseAll();
+                Assert.Equal(5, target.Rows.Count);
+
+                // Ensure that nested rows were collapsed, i.e. only the first level of rows is
+                // visible after expanding now.
+                target.Expand(0);
+                Assert.Equal(8, target.Rows.Count);
+            }
         }
 
         public class ExpansionBinding


### PR DESCRIPTION
When using a filter calling the `ExpandRecursive()` API, it's useful to have the `isExpanded` filter value propagated to all nodes in the hierarchy, not just those below an expanded one.

Previously, the `isExpanded` filter was only applied to nodes that were below a expanded one, leaving out nodes that weren't. This PR ensures that the `isExpanded` filter now propagates to all nodes within the hierarchy. 

Performance is still good.