### PR TITLE
fix the empty cell value edit crash

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
@@ -49,7 +49,16 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public string? Text
         {
             get => _value?.ToString();
-            set => Value = (T?)Convert.ChangeType(value, typeof(T));
+            set{
+                if (string.IsNullOrEmpty(value))
+                {
+                    Value = default(T?);
+                }
+                else
+                {
+                    Value = (T?)Convert.ChangeType(value, typeof(T));
+                }
+            }
         }
 
         public T? Value


### PR DESCRIPTION
when  i set a TextColumn like this:
```cs
   new TextColumn<Country, int>("GDP", x => x.GDP,(x,n)=>{ }, new GridLength(3, GridUnitType.Star), new()
```
and i edit the GDP value by empty string,like backspace the value.and then enter 

the app crash,the reason is that 
```
System.FormatException: The input string '' was not in a correct format.
11:20:17:288	   at System.Number.ThrowFormatException[TChar](ReadOnlySpan`1 value)
11:20:17:288	   at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
11:20:17:288	   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
11:20:17:288	   at Avalonia.Controls.Models.TreeDataGrid.TextCell`1.set_Text(String value) in /_/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs:line 52
```