### PR TITLE
Make switching between flat and tree layouts easier.

### DIFF
--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -65,6 +65,11 @@
                     DockPanel.Dock="Right">
             Cell Selection
           </CheckBox>
+          <CheckBox IsChecked="{Binding Files.FlatList}"
+                    Margin="4 0 0 0"
+                    DockPanel.Dock="Right">
+            Flat
+          </CheckBox>
           <TextBox Text="{Binding Files.SelectedPath, Mode=OneWay}"
                    Margin="4 0 0 0"
                    VerticalContentAlignment="Center"

--- a/src/Avalonia.Controls.TreeDataGrid/ITreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/ITreeDataGridSource.cs
@@ -23,9 +23,9 @@ namespace Avalonia.Controls
         IRows Rows { get; }
 
         /// <summary>
-        /// Gets the selection model.
+        /// Gets or sets the selection model.
         /// </summary>
-        ITreeDataGridSelection? Selection { get; }
+        ITreeDataGridSelection? Selection { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether the data source is hierarchical.
@@ -84,8 +84,8 @@ namespace Avalonia.Controls
     public interface ITreeDataGridSource<TModel> : ITreeDataGridSource
     {
         /// <summary>
-        /// Gets the items in the data source.
+        /// Gets or sets the items in the data source.
         /// </summary>
-        new IEnumerable<TModel> Items { get; }
+        new IEnumerable<TModel> Items { get; set; }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnList.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnList.cs
@@ -9,6 +9,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     /// </summary>
     public class ColumnList<TModel> : NotifyingListBase<IColumn<TModel>>, IColumns
     {
+        private bool _initialized;
         private double _viewportWidth;
 
         public event EventHandler? LayoutInvalidated;
@@ -22,6 +23,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public Size CellMeasured(int columnIndex, int rowIndex, Size size)
         {
             var column = (IUpdateColumnLayout)this[columnIndex];
+            _initialized = true;
             return new Size(column.CellMeasured(size.Width, rowIndex), size.Height);
         }
 
@@ -103,7 +105,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             if (_viewportWidth != viewport.Width)
             {
                 _viewportWidth = viewport.Width;
-                UpdateColumnSizes();
+                if (_initialized)
+                    UpdateColumnSizes();
             }
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -427,7 +427,7 @@ namespace Avalonia.Controls.Primitives
             // viewport.
             Viewport = e.EffectiveViewport.Size == default ? 
                 s_invalidViewport :
-                e.EffectiveViewport.Intersect(new(Bounds.Size));
+                Intersect(e.EffectiveViewport, new(Bounds.Size));
 
             _isWaitingForViewportUpdate = false;
 
@@ -729,6 +729,24 @@ namespace Avalonia.Controls.Primitives
         }
 
         private static bool HasInfinity(Size s) => double.IsInfinity(s.Width) || double.IsInfinity(s.Height);
+
+        private static Rect Intersect(Rect a, Rect b)
+        {
+            // Hack fix for https://github.com/AvaloniaUI/Avalonia/issues/15075
+            var newLeft = (a.X > b.X) ? a.X : b.X;
+            var newTop = (a.Y > b.Y) ? a.Y : b.Y;
+            var newRight = (a.Right < b.Right) ? a.Right : b.Right;
+            var newBottom = (a.Bottom < b.Bottom) ? a.Bottom : b.Bottom;
+
+            if ((newRight >= newLeft) && (newBottom >= newTop))
+            {
+                return new Rect(newLeft, newTop, newRight - newLeft, newBottom - newTop);
+            }
+            else
+            {
+                return default;
+            }
+        }
 
         private struct MeasureViewport
         {

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
@@ -312,6 +312,46 @@ namespace Avalonia.Controls.TreeDataGridTests
             Assert.True(double.IsNaN(columns[3].ActualWidth));
         }
 
+        [AvaloniaFact(Timeout = 10000)]
+        public void Columns_Are_Correctly_Sized_After_Changing_Source()
+        {
+            // Create the initial target with 2 columns and make sure our preconditions are correct.
+            var (target, items) = CreateTarget(columns: new IColumn<Model>[]
+            {
+                new TextColumn<Model, int>("ID", x => x.Id, width: new GridLength(1, GridUnitType.Star)),
+                new TextColumn<Model, string?>("Title1", x => x.Title, options: MinWidth(50)),
+            });
+
+            AssertColumnIndexes(target, 0, 2);
+
+            // Create a new source and assign it to the TreeDataGrid.
+            var newSource = new FlatTreeDataGridSource<Model>(items)
+            {
+                Columns =
+                {
+                    new TextColumn<Model, int>("ID", x => x.Id, width: new GridLength(1, GridUnitType.Star)),
+                    new TextColumn<Model, string?>("Title1", x => x.Title, options: MinWidth(20)),
+                    new TextColumn<Model, string?>("Title2", x => x.Title, options: MinWidth(20)),
+                }
+            };
+
+            target.Source = newSource;
+
+            // The columns should not have an ActualWidth yet.
+            Assert.True(double.IsNaN(newSource.Columns[0].ActualWidth));
+            Assert.True(double.IsNaN(newSource.Columns[1].ActualWidth));
+            Assert.True(double.IsNaN(newSource.Columns[2].ActualWidth));
+
+            // Do a layout pass and check that the columns have been correctly sized.
+            target.UpdateLayout();
+            AssertColumnIndexes(target, 0, 3);
+
+            var columns = (ColumnList<Model>)target.Columns!;
+            Assert.Equal(60, columns[0].ActualWidth);
+            Assert.Equal(20, columns[1].ActualWidth);
+            Assert.Equal(20, columns[2].ActualWidth);
+        }
+
         public class RemoveItems
         {
             [AvaloniaFact(Timeout = 10000)]


### PR DESCRIPTION
- Add setters for `Items` and `Selection` on `ITreeDataGridSource`: this allows one to more easily operate on both flat and tree sources using the same interface
- Fix an issue where columns were not being correctly resized when switching between sources
- Add a simple example to "Files" view of switching between tree and flat views (flat view isn't really particularly functional currently, it's just intended as a simple example for the moment)

Note that this PR does not add a `RowSelection` or `CellSelection` property to `ITreeDataGridSource`, as it's envisioned that future sources will not want to expose these. Given that those properties are just casting `Selection` to the relevant type, it's easy enough to do this using e.g. an extension method anyway if desired.