### PR TITLE
Feat/text column formatting

### DIFF
--- a/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Models.TreeDataGrid;
@@ -32,7 +33,9 @@ namespace TreeDataGridDemo.ViewModels
                     new TextColumn<Country, int>("GDP", x => x.GDP, new GridLength(3, GridUnitType.Star), new()
                     {
                         TextAlignment = Avalonia.Media.TextAlignment.Right,
-                        MaxWidth = new GridLength(150)
+                        MaxWidth = new GridLength(150),
+                        StringFormat = "{0:C}", // Format as Currency
+                        FormatCultureInfo = CultureInfo.GetCultureInfo("en-US"), // Format this as USD
                     }),
                 }
             };

--- a/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
@@ -26,7 +26,7 @@ namespace TreeDataGridDemo.ViewModels
                         IsTextSearchEnabled = true,
                     }),
                     new TemplateColumn<Country>("Region", "RegionCell", "RegionEditCell"),
-                    new TextColumn<Country, int>("Population", x => x.Population, new GridLength(3, GridUnitType.Star)),
+                    new TextColumn<Country, int>("Population", x => x.Population, new GridLength(3, GridUnitType.Star), new TextColumnOptions<Country>{StringFormat = "{0:N}"}),
                     new TextColumn<Country, int>("Area", x => x.Area, new GridLength(3, GridUnitType.Star)),
                     new TextColumn<Country, int>("GDP", x => x.GDP, new GridLength(3, GridUnitType.Star), new()
                     {

--- a/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
@@ -26,7 +26,8 @@ namespace TreeDataGridDemo.ViewModels
                         IsTextSearchEnabled = true,
                     }),
                     new TemplateColumn<Country>("Region", "RegionCell", "RegionEditCell"),
-                    new TextColumn<Country, int>("Population", x => x.Population, new GridLength(3, GridUnitType.Star), new TextColumnOptions<Country>{StringFormat = "{0:N}"}),
+                    new TextColumn<Country, int>("Population", x => x.Population, new GridLength(3, GridUnitType.Star),
+                        new TextColumnOptions<Country> { StringFormat = "{0:N}" }),
                     new TextColumn<Country, int>("Area", x => x.Area, new GridLength(3, GridUnitType.Star)),
                     new TextColumn<Country, int>("GDP", x => x.GDP, new GridLength(3, GridUnitType.Star), new()
                     {

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCell.cs
@@ -13,6 +13,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         string? Text { get; set; }
 
         /// <summary>
+        /// Format to use for the string
+        /// </summary>
+        string StringFormat { get; }
+
+        /// <summary>
         /// Gets the cell's text trimming mode.
         /// </summary>
         TextTrimming TextTrimming { get; }
@@ -21,7 +26,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// Gets the cell's text wrapping mode.
         /// </summary>
         TextWrapping TextWrapping { get; }
-        
+
+        /// <summary>
         /// Gets the cell's text alignment mode.
         /// </summary>
         TextAlignment TextAlignment { get; }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCell.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Media;
+﻿using System.Globalization;
+
+using Avalonia.Media;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
@@ -16,6 +18,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// Format to use for the string
         /// </summary>
         string StringFormat { get; }
+
+        /// <summary>
+        /// Culture info used in conjunction with <see cref="StringFormat"/>
+        /// </summary>
+        CultureInfo FormatCultureInfo { get; }
 
         /// <summary>
         /// Gets the cell's text trimming mode.

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCellOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCellOptions.cs
@@ -5,6 +5,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     public interface ITextCellOptions : ICellOptions
     {
         /// <summary>
+        /// Format to use for the string
+        /// </summary>
+        string StringFormat { get; }
+
+        /// <summary>
         /// Gets the text trimming mode for the cell.
         /// </summary>
         TextTrimming TextTrimming { get; }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCellOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCellOptions.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Media;
+﻿using System.Globalization;
+
+using Avalonia.Media;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
@@ -8,6 +10,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// Format to use for the string
         /// </summary>
         string StringFormat { get; }
+
+        /// <summary>
+        /// Culture info used in conjunction with <see cref="StringFormat"/>
+        /// </summary>
+        CultureInfo FormatCultureInfo { get; }
 
         /// <summary>
         /// Gets the text trimming mode for the cell.

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
@@ -42,6 +42,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public bool CanEdit => !IsReadOnly;
         public BeginEditGestures EditGestures => _options?.BeginEditGestures ?? BeginEditGestures.Default;
         public bool IsReadOnly { get; }
+        public string StringFormat => _options?.StringFormat ?? "{0}";
         public TextTrimming TextTrimming => _options?.TextTrimming ?? TextTrimming.None;
         public TextWrapping TextWrapping => _options?.TextWrapping ?? TextWrapping.NoWrap;
         public TextAlignment TextAlignment => _options?.TextAlignment ?? TextAlignment.Left;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Reactive.Subjects;
 using Avalonia.Data;
 using Avalonia.Media;
@@ -43,6 +44,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public BeginEditGestures EditGestures => _options?.BeginEditGestures ?? BeginEditGestures.Default;
         public bool IsReadOnly { get; }
         public string StringFormat => _options?.StringFormat ?? "{0}";
+        public CultureInfo FormatCultureInfo => _options?.FormatCultureInfo ?? CultureInfo.InvariantCulture;
         public TextTrimming TextTrimming => _options?.TextTrimming ?? TextTrimming.None;
         public TextWrapping TextWrapping => _options?.TextWrapping ?? TextWrapping.NoWrap;
         public TextAlignment TextAlignment => _options?.TextAlignment ?? TextAlignment.Left;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
@@ -14,6 +14,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         public bool IsTextSearchEnabled { get; set; }
 
         /// <summary>
+        /// Gets or sets the format string for the cells in the column.
+        /// </summary>
+        public string StringFormat { get; set; } = "{0}";
+
+        /// <summary>
         /// Gets or sets the text trimming mode for the cells in the column.
         /// </summary>
         public TextTrimming TextTrimming { get; set; } = TextTrimming.CharacterEllipsis;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Media;
+﻿using System.Globalization;
+
+using Avalonia.Media;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
@@ -17,6 +19,11 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// Gets or sets the format string for the cells in the column.
         /// </summary>
         public string StringFormat { get; set; } = "{0}";
+
+        /// <summary>
+        /// Culture info used in conjunction with <see cref="StringFormat"/>
+        /// </summary>
+        public CultureInfo FormatCultureInfo { get; } = CultureInfo.InvariantCulture;
 
         /// <summary>
         /// Gets or sets the text trimming mode for the cells in the column.

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// <summary>
         /// Culture info used in conjunction with <see cref="StringFormat"/>
         /// </summary>
-        public CultureInfo FormatCultureInfo { get; } = CultureInfo.InvariantCulture;
+        public CultureInfo FormatCultureInfo { get; set; } = CultureInfo.InvariantCulture;
 
         /// <summary>
         /// Gets or sets the text trimming mode for the cells in the column.

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
@@ -9,6 +9,11 @@ namespace Avalonia.Controls.Primitives
 {
     public class TreeDataGridTextCell : TreeDataGridCell
     {
+        public static readonly DirectProperty<TreeDataGridTextCell, string> StringFormatProperty =
+            AvaloniaProperty.RegisterDirect<TreeDataGridTextCell, string>(
+                nameof(StringFormat),
+                o => o.StringFormat);
+
         public static readonly DirectProperty<TreeDataGridTextCell, TextTrimming> TextTrimmingProperty =
             AvaloniaProperty.RegisterDirect<TreeDataGridTextCell, TextTrimming>(
                 nameof(TextTrimming),
@@ -32,10 +37,17 @@ namespace Avalonia.Controls.Primitives
                 (o,v)=> o.TextAlignment = v);
 
         private string? _value;
+        private string _stringFormat = "{0}";
         private TextBox? _edit;
         private TextTrimming _textTrimming = TextTrimming.CharacterEllipsis;
         private TextWrapping _textWrapping = TextWrapping.NoWrap;
         private TextAlignment _textAlignment = TextAlignment.Left;
+
+        public string StringFormat
+        {
+            get => _stringFormat;
+            set => SetAndRaise(StringFormatProperty, ref _stringFormat, value);
+        }
 
         public TextTrimming TextTrimming
         {
@@ -71,7 +83,7 @@ namespace Avalonia.Controls.Primitives
             int columnIndex,
             int rowIndex)
         {
-            Value = model.Value?.ToString();
+            Value = string.Format((model as ITextCell)?.StringFormat ?? "{0}", model.Value);
             TextTrimming = (model as ITextCell)?.TextTrimming ?? TextTrimming.CharacterEllipsis;
             TextWrapping = (model as ITextCell)?.TextWrapping ?? TextWrapping.NoWrap;
             TextAlignment = (model as ITextCell)?.TextAlignment ?? TextAlignment.Left;
@@ -103,7 +115,7 @@ namespace Avalonia.Controls.Primitives
             base.OnModelPropertyChanged(sender, e);
 
             if (e.PropertyName == nameof(ITextCell.Value))
-                Value = Model?.Value?.ToString();
+                Value = string.Format((Model as ITextCell)?.StringFormat ?? "{0}", Model?.Value);
         }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Globalization;
+
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Input;
@@ -13,6 +15,11 @@ namespace Avalonia.Controls.Primitives
             AvaloniaProperty.RegisterDirect<TreeDataGridTextCell, string>(
                 nameof(StringFormat),
                 o => o.StringFormat);
+
+        public static readonly DirectProperty<TreeDataGridTextCell, CultureInfo> FormatCultureInfoProperty =
+            AvaloniaProperty.RegisterDirect<TreeDataGridTextCell, CultureInfo>(
+                nameof(FormatCultureInfo),
+                o => o.FormatCultureInfo);
 
         public static readonly DirectProperty<TreeDataGridTextCell, TextTrimming> TextTrimmingProperty =
             AvaloniaProperty.RegisterDirect<TreeDataGridTextCell, TextTrimming>(
@@ -38,6 +45,7 @@ namespace Avalonia.Controls.Primitives
 
         private string? _value;
         private string _stringFormat = "{0}";
+        private CultureInfo _formatCultureInfo = CultureInfo.InvariantCulture;
         private TextBox? _edit;
         private TextTrimming _textTrimming = TextTrimming.CharacterEllipsis;
         private TextWrapping _textWrapping = TextWrapping.NoWrap;
@@ -47,6 +55,12 @@ namespace Avalonia.Controls.Primitives
         {
             get => _stringFormat;
             set => SetAndRaise(StringFormatProperty, ref _stringFormat, value);
+        }
+
+        public CultureInfo FormatCultureInfo
+        {
+            get => _formatCultureInfo;
+            set => SetAndRaise(FormatCultureInfoProperty, ref _formatCultureInfo, value);
         }
 
         public TextTrimming TextTrimming
@@ -83,7 +97,10 @@ namespace Avalonia.Controls.Primitives
             int columnIndex,
             int rowIndex)
         {
-            Value = string.Format((model as ITextCell)?.StringFormat ?? "{0}", model.Value);
+            var format = (model as ITextCell)?.StringFormat ?? "{0}";
+            var culture = (model as ITextCell)?.FormatCultureInfo ?? CultureInfo.InvariantCulture;
+
+            Value = string.Format(culture, format, model.Value);
             TextTrimming = (model as ITextCell)?.TextTrimming ?? TextTrimming.CharacterEllipsis;
             TextWrapping = (model as ITextCell)?.TextWrapping ?? TextWrapping.NoWrap;
             TextAlignment = (model as ITextCell)?.TextAlignment ?? TextAlignment.Left;
@@ -114,8 +131,11 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnModelPropertyChanged(sender, e);
 
-            if (e.PropertyName == nameof(ITextCell.Value))
-                Value = string.Format((Model as ITextCell)?.StringFormat ?? "{0}", Model?.Value);
+            if (e.PropertyName != nameof(ITextCell.Value)) return;
+            var format = (Model as ITextCell)?.StringFormat ?? "{0}";
+            var culture = (Model as ITextCell)?.FormatCultureInfo ?? CultureInfo.InvariantCulture;
+
+            Value = string.Format(culture, format, Model?.Value);
         }
     }
 }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTextCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTextCellTests.cs
@@ -42,6 +42,26 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
             Assert.Equal(expected, cell.Value);
         }
 
+        [AvaloniaTheory(Timeout = 10000)]
+        [InlineData(10.1, "10.1")]
+        [InlineData(20.12345, "20.12345")]
+        [InlineData(5050.50, "5050.5")]
+        public void Formats_Doublet_With_Default_Formatter_Properly(double input, string expected)
+        {
+            var cell = SetupCellForType(input, null, null);
+            Assert.Equal(expected, cell.Value);
+        }
+
+        [AvaloniaTheory(Timeout = 10000)]
+        [InlineData(1_000_000, "1000000")]
+        [InlineData(2032, "2032")]
+        [InlineData(5050, "5050")]
+        public void Formats_Int_With_Default_Formatter_Properly(int input, string expected)
+        {
+            var cell = SetupCellForType(input, null, null);
+            Assert.Equal(expected, cell.Value);
+        }
+
         private static TreeDataGridTextCell SetupCellForType<T>(T input, CultureInfo? cultureInfo, string? formatString)
         {
             var subject = new Subject<BindingValue<T>>();

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTextCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTextCellTests.cs
@@ -1,0 +1,50 @@
+using System.Reactive.Subjects;
+
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+
+using Xunit;
+
+namespace Avalonia.Controls.TreeDataGridTests.Primitives
+{
+    public class TreeDataGridTextCellTests
+    {
+        [AvaloniaTheory(Timeout = 10000)]
+        [InlineData(10.1, "{0:n3}", "10.100")]
+        [InlineData(20.12345, "{0:n2}", "20.12")]
+        [InlineData(5050.50, "{0:n2}", "5,050.50")]
+        public void Formats_Double_Properly(double input, string formatString, string expected)
+        {
+            var cell = SetupCellForType(input, formatString);
+            Assert.Equal(expected, cell.Value);
+        }
+
+        [AvaloniaTheory(Timeout = 10000)]
+        [InlineData(1_000_000, "{0:n0}", "1,000,000")]
+        [InlineData(2032, "{0:n2}", "2,032.00")]
+        [InlineData(5050, "{0}", "5050")]
+        [InlineData(5050, "{0:c}", "5050.00")]
+        public void Formats_Int_Properly(int input, string formatString, string expected)
+        {
+            var cell = SetupCellForType(input, formatString);
+            Assert.Equal(expected, cell.Value);
+        }
+
+        private static TreeDataGridTextCell SetupCellForType<T>(T input, string? formatString)
+        {
+            var subject = new Subject<BindingValue<T>>();
+            var cell = new TreeDataGridTextCell();
+            var options = new TextColumnOptions<T>();
+            if (formatString is not null)
+            {
+                options.StringFormat = formatString;
+            }
+            var model = new TextCell<T>(subject, true, options);
+            subject.OnNext(new BindingValue<T>(input));
+            cell.Realize(new TestElementFactory(), null, model, 0, 0);
+            return cell;
+        }
+    }
+}

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTextCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridTextCellTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reactive.Subjects;
 
 using Avalonia.Controls.Models.TreeDataGrid;
@@ -12,35 +13,45 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
     public class TreeDataGridTextCellTests
     {
         [AvaloniaTheory(Timeout = 10000)]
-        [InlineData(10.1, "{0:n3}", "10.100")]
-        [InlineData(20.12345, "{0:n2}", "20.12")]
-        [InlineData(5050.50, "{0:n2}", "5,050.50")]
-        public void Formats_Double_Properly(double input, string formatString, string expected)
+        [InlineData(10.1, null, "{0:n3}", "10.100")]
+        [InlineData(20.12345, null, "{0:n2}", "20.12")]
+        [InlineData(5050.50, null, "{0:n2}", "5,050.50")]
+        [InlineData(5050.50, "en-US", "{0:C}", "$5,050.50")]
+        public void Formats_Double_Properly(double input, string? cultureString, string formatString, string expected)
         {
-            var cell = SetupCellForType(input, formatString);
+            CultureInfo? culture = null;
+            if (cultureString is not null)
+                culture = CultureInfo.GetCultureInfo(cultureString);
+
+            var cell = SetupCellForType(input, culture, formatString);
             Assert.Equal(expected, cell.Value);
         }
 
         [AvaloniaTheory(Timeout = 10000)]
-        [InlineData(1_000_000, "{0:n0}", "1,000,000")]
-        [InlineData(2032, "{0:n2}", "2,032.00")]
-        [InlineData(5050, "{0}", "5050")]
-        [InlineData(5050, "{0:c}", "5050.00")]
-        public void Formats_Int_Properly(int input, string formatString, string expected)
+        [InlineData(1_000_000, null, "{0:n0}", "1,000,000")]
+        [InlineData(2032, null, "{0:n2}", "2,032.00")]
+        [InlineData(5050, null, "{0}", "5050")]
+        [InlineData(5050, "en-US", "{0:C}", "$5,050.00")]
+        public void Formats_Int_Properly(int input, string? cultureString, string formatString, string expected)
         {
-            var cell = SetupCellForType(input, formatString);
+            CultureInfo? culture = null;
+            if (cultureString is not null)
+                culture = CultureInfo.GetCultureInfo(cultureString);
+
+            var cell = SetupCellForType(input, culture, formatString);
             Assert.Equal(expected, cell.Value);
         }
 
-        private static TreeDataGridTextCell SetupCellForType<T>(T input, string? formatString)
+        private static TreeDataGridTextCell SetupCellForType<T>(T input, CultureInfo? cultureInfo, string? formatString)
         {
             var subject = new Subject<BindingValue<T>>();
             var cell = new TreeDataGridTextCell();
             var options = new TextColumnOptions<T>();
             if (formatString is not null)
-            {
                 options.StringFormat = formatString;
-            }
+
+            if (cultureInfo is not null)
+                options.FormatCultureInfo = cultureInfo;
             var model = new TextCell<T>(subject, true, options);
             subject.OnNext(new BindingValue<T>(input));
             cell.Realize(new TestElementFactory(), null, model, 0, 0);


### PR DESCRIPTION
Closes #278 

Adds the property `StringFormat` to `TextColumnOptions`. This new option allows us to specify a custom string format for each cell, without needing to use `TemplateColumns`.