### PR TITLE
fix: Prevent changing DragEffects in TreeDataGrid DragDrop event-handlers if AutoDragDropRows=false

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -435,10 +435,10 @@ namespace Avalonia.Controls
 
         internal void RaiseRowDragStarted(PointerEventArgs trigger)
         {
-            if (_source is null || RowSelection is null)
+            if (!AutoDragDropRows || _source is null || RowSelection is null)
                 return;
 
-            var allowedEffects = AutoDragDropRows && !_source.IsSorted ?
+            var allowedEffects = !_source.IsSorted ?
                 DragDropEffects.Move :
                 DragDropEffects.None;
             var route = BuildEventRoute(RowDragStartedEvent);
@@ -596,8 +596,7 @@ namespace Avalonia.Controls
             [NotNullWhen(true)] out DragInfo? data,
             out TreeDataGridRowDropPosition position)
         {
-            if (!AutoDragDropRows ||
-                e.Data.Get(DragInfo.DataFormat) is not DragInfo di ||
+            if (e.Data.Get(DragInfo.DataFormat) is not DragInfo di ||
                 _source is null ||
                 _source.IsSorted ||
                 di.Source != _source)
@@ -628,6 +627,9 @@ namespace Avalonia.Controls
 
         private void OnDragOver(DragEventArgs e)
         {
+            if (!AutoDragDropRows)
+                return;
+
             if (!TryGetRow(e.Source as Control, out var row))
             {
                 e.DragEffects = DragDropEffects.None;
@@ -664,11 +666,17 @@ namespace Avalonia.Controls
 
         private void OnDragLeave(RoutedEventArgs e)
         {
+            if (!AutoDragDropRows)
+                return;
+
             StopDrag();
         }
 
         private void OnDrop(DragEventArgs e)
         {
+            if (!AutoDragDropRows)
+                return;
+
             StopDrag();
 
             if (!TryGetRow(e.Source as Control, out var row))


### PR DESCRIPTION
- AutoDragDropRows check moved to the beginning of DragDrop event-handlers, before they perform any actions. This is necessary for inherited from TreeDataGrid types, with custom DragDrop event-handlers. Now DragEventArgs.DragDropEffects is always None in inherited types, even if AutoDragDropRows is false.

- Also AutoDragDropRows check moved to the beginning of RaiseRowDragStarted method, to prevent RowDragStartedEvent.