### PR TITLE
Fixing a problem with updating data in CheckBoxColumn

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCheckBoxCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCheckBoxCell.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
 using Avalonia.Input;
@@ -70,6 +71,21 @@ namespace Avalonia.Controls.Primitives
             }
 
             base.Realize(factory, selection, model, columnIndex, rowIndex);
+            SubscribeToModelChanges();
+        }
+
+        public override void Unrealize()
+        {
+            UnsubscribeFromModelChanges();
+            base.Unrealize();
+        }
+        
+        protected override void OnModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            base.OnModelPropertyChanged(sender, e);
+
+            if (e.PropertyName == nameof(CheckBoxCell.Value) && Model is CheckBoxCell checkBoxCell)
+                Value = checkBoxCell.Value;
         }
 
         protected override void OnPointerPressed(PointerPressedEventArgs e)


### PR DESCRIPTION
CheckBoxColumn does not update its value when a property changes in the view model, although it raises the RaisePropertyChanged event. When debugging, you can see that the changes reach the CheckBoxCell, but do not get to the TreeDataGridCheckBoxCell, since this cell is not subscribed to CheckBoxCell properties changes. 

This PR should fix this problem