### PR TITLE
Ignore control characters on text input

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -302,7 +302,7 @@ namespace Avalonia.Controls.Selection
             if (valueSelector != null && model != null)
             {
                 var value = valueSelector(model);
-                if (value != null && value.ToUpper().StartsWith(candidatePattern, StringComparison.Ordinal))
+                if (value != null && value.ToUpper().StartsWith(candidatePattern))
                 {
                     UpdateSelection(treeDataGrid, newIndex, true);
                     treeDataGrid.RowsPresenter?.BringIntoView(newIndex);

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs
@@ -302,7 +302,7 @@ namespace Avalonia.Controls.Selection
             if (valueSelector != null && model != null)
             {
                 var value = valueSelector(model);
-                if (value != null && value.ToUpper().StartsWith(candidatePattern))
+                if (value != null && value.ToUpper().StartsWith(candidatePattern, StringComparison.Ordinal))
                 {
                     UpdateSelection(treeDataGrid, newIndex, true);
                     treeDataGrid.RowsPresenter?.BringIntoView(newIndex);

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -368,6 +368,10 @@ namespace Avalonia.Controls
         protected override void OnTextInput(TextInputEventArgs e)
         {
             base.OnTextInput(e);
+
+            if (e.Text is { Length: > 0 } && char.IsControl(e.Text[0]))
+                return;
+
             _selection?.OnTextInput(this, e);
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -368,10 +368,6 @@ namespace Avalonia.Controls
         protected override void OnTextInput(TextInputEventArgs e)
         {
             base.OnTextInput(e);
-
-            if (e.Text is { Length: > 0 } && char.IsControl(e.Text[0]))
-                return;
-
             _selection?.OnTextInput(this, e);
         }
 


### PR DESCRIPTION
When hitting the `Escape` key or other control keys, the [`_selection?.OnTextInput()`](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/blob/a0da0977d252efdb24da5154318cca043d71eee3/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs#L371) method is executed, passing the string  "\u001B" (ASCII 27 control char) to the [`HandleTextInput`](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/blob/a0da0977d252efdb24da5154318cca043d71eee3/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs#L117) method.

This method matches every row because [this comparison](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/blob/a0da0977d252efdb24da5154318cca043d71eee3/src/Avalonia.Controls.TreeDataGrid/Selection/TreeDataGridRowSelectionModel.cs#L305) always returns true (see [this .NET fiddle](https://dotnetfiddle.net/k8v1p4)), causing that the selection is moved 1 row down every time the user hits the `Escape` key:

```csharp
string escapeSequence = "\u001B"; // ESC - ASCII char 27
Console.WriteLine("something".ToUpper().StartsWith(escapeSequence));

True
```
This PR changes filters out control characters on method `OnTextInput`.

@grokys Question: Should Avalonia filter out these events in `OnTextInput` when the text contains control characters?