### PR TITLE
Check for null ItemsView in TreeSelectedItems.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectedItems.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectedItems.cs
@@ -56,7 +56,8 @@ namespace Avalonia.Controls.Selection
             {
                 for (var i = range.Begin; i <= range.End; ++i)
                 {
-                    yield return node.ItemsView![i];
+                    if (node.ItemsView is not null)
+                        yield return node.ItemsView[i];
                 }
             }
 


### PR DESCRIPTION
A customer reported a `NullReferenceException` in `TreeSelectedItemsBase`:

```
Unexpected error: Object reference not set to an instance of an object.
  at Avalonia.Controls.Selection.TreeSelectedItemsBase`1.EnumerateNode(TreeSelectionNode`1 node)+MoveNext()
   at Avalonia.Controls.Selection.TreeSelectedItemsBase`1.EnumerateNode(TreeSelectionNode`1 node)+MoveNext()
   at Avalonia.Controls.Selection.TreeSelectedItemsBase`1.EnumerateNode(TreeSelectionNode`1 node)+MoveNext()
   at Avalonia.Controls.Selection.TreeSelectedItemsBase`1.EnumerateNode(TreeSelectionNode`1 node)+MoveNext()
   at Avalonia.Controls.Selection.TreeSelectedItemsBase`1.EnumerateNode(TreeSelectionNode`1 node)+MoveNext()
   at Avalonia.Controls.Selection.TreeSelectedItemsBase`1.EnumerateNode(TreeSelectionNode`1 node)+MoveNext()
   at Avalonia.Controls.Selection.TreeSelectedItemsBase`1.GetEnumerator()+MoveNext()
   at Avalonia.Controls.Selection.TreeSelectedItems`1.System.Collections.Generic.IEnumerable<System.Object>.GetEnumerator()+MoveNext()
```

The only thing that looks suspect is this `!` operator in `EnumerateNode`. This PR puts a null check around that indexer instead of ignoring the null warning.