### PR TITLE
Trimmability

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,13 +5,14 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>12</LangVersion>
     <!-- https://github.com/dotnet/msbuild/issues/2661 -->
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
     <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
   <PropertyGroup>
     <AvaloniaVersion>11.0.0</AvaloniaVersion>
+    <AvaloniaSamplesVersion>11.1.3</AvaloniaSamplesVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -2,5 +2,6 @@
   "sdk": {
     "version": "8.0.101",
     "rollForward": "latestFeature"
+    "allowPrerelease": false
   }
 }

--- a/samples/TreeDataGridDemo/MainWindow.axaml
+++ b/samples/TreeDataGridDemo/MainWindow.axaml
@@ -6,7 +6,8 @@
         xmlns:vm="using:TreeDataGridDemo.ViewModels"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="TreeDataGridDemo.MainWindow"
-        Title="TreeDataGridDemo">
+        Title="TreeDataGridDemo"
+        x:DataType="vm:MainWindowViewModel">
   <TabControl Name="tabs">
     <TabItem Header="Countries">
       <DockPanel>
@@ -125,7 +126,7 @@
         <TextBlock Classes="realized-count" DockPanel.Dock="Bottom"/>
         <TreeDataGrid Name="wikipedia" Source="{Binding Wikipedia.Source}">
           <TreeDataGrid.Resources>
-            <DataTemplate x:Key="WikipediaImageCell">
+            <DataTemplate x:Key="WikipediaImageCell" x:DataType="m:OnThisDayArticle">
               <Image Source="{Binding Image}"/>
             </DataTemplate>
           </TreeDataGrid.Resources>

--- a/samples/TreeDataGridDemo/MainWindow.axaml.cs
+++ b/samples/TreeDataGridDemo/MainWindow.axaml.cs
@@ -20,7 +20,6 @@ namespace TreeDataGridDemo
         public MainWindow()
         {
             InitializeComponent();
-            this.AttachDevTools();
             DataContext = new MainWindowViewModel();
 
             _tabs = this.FindControl<TabControl>("tabs");
@@ -73,11 +72,6 @@ namespace TreeDataGridDemo
             var index = vm.Countries.Source.Rows.Count - 1;
             countries.RowsPresenter!.BringIntoView(index);
             countries.TryGetRow(index)?.Focus();
-        }
-
-        private void InitializeComponent()
-        {
-            AvaloniaXamlLoader.Load(this);
         }
 
         private void MainWindow_Activated(object? sender, EventArgs e)

--- a/samples/TreeDataGridDemo/Models/DragDropItem.cs
+++ b/samples/TreeDataGridDemo/Models/DragDropItem.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Linq;
-using ReactiveUI;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace TreeDataGridDemo.Models
 {
-    public class DragDropItem : ReactiveObject
+    public class DragDropItem : ObservableObject
     {
         private static Random _random = new Random(0);
         private ObservableCollection<DragDropItem>? _children;
@@ -18,13 +18,13 @@ namespace TreeDataGridDemo.Models
         public bool AllowDrag
         {
             get => _allowDrag;
-            set => this.RaiseAndSetIfChanged(ref _allowDrag, value);
+            set => SetProperty(ref _allowDrag, value);
         }
 
         public bool AllowDrop
         {
             get => _allowDrop;
-            set => this.RaiseAndSetIfChanged(ref _allowDrop, value);
+            set => SetProperty(ref _allowDrop, value);
         }
 
         public ObservableCollection<DragDropItem> Children => _children ??= CreateRandomItems();

--- a/samples/TreeDataGridDemo/Models/FileTreeNodeModel.cs
+++ b/samples/TreeDataGridDemo/Models/FileTreeNodeModel.cs
@@ -4,11 +4,11 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using Avalonia.Threading;
-using ReactiveUI;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace TreeDataGridDemo.Models
 {
-    public class FileTreeNodeModel : ReactiveObject, IEditableObject
+    public class FileTreeNodeModel : ObservableObject, IEditableObject
     {
         private string _path;
         private string _name;
@@ -42,37 +42,37 @@ namespace TreeDataGridDemo.Models
         public string Path 
         {
             get => _path;
-            private set => this.RaiseAndSetIfChanged(ref _path, value);
+            private set => SetProperty(ref _path, value);
         }
 
         public string Name 
         {
             get => _name;
-            private set => this.RaiseAndSetIfChanged(ref _name, value);
+            private set => SetProperty(ref _name, value);
         }
 
         public long? Size 
         {
             get => _size;
-            private set => this.RaiseAndSetIfChanged(ref _size, value);
+            private set => SetProperty(ref _size, value);
         }
 
         public DateTimeOffset? Modified 
         {
             get => _modified;
-            private set => this.RaiseAndSetIfChanged(ref _modified, value);
+            private set => SetProperty(ref _modified, value);
         }
 
         public bool HasChildren
         {
             get => _hasChildren;
-            private set => this.RaiseAndSetIfChanged(ref _hasChildren, value);
+            private set => SetProperty(ref _hasChildren, value);
         }
 
         public bool IsExpanded
         {
             get => _isExpanded;
-            set => this.RaiseAndSetIfChanged(ref _isExpanded, value);
+            set => SetProperty(ref _isExpanded, value);
         }
 
         public bool IsChecked { get; set; }

--- a/samples/TreeDataGridDemo/Program.cs
+++ b/samples/TreeDataGridDemo/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using Avalonia;
-using Avalonia.ReactiveUI;
 
 namespace TreeDataGridDemo
 {
@@ -21,7 +20,6 @@ namespace TreeDataGridDemo
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
-                .UseReactiveUI()
                 .LogToTrace();
     }
 }

--- a/samples/TreeDataGridDemo/TreeDataGridDemo.csproj
+++ b/samples/TreeDataGridDemo/TreeDataGridDemo.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaSamplesVersion)" Condition="'$(Configuration)' != 'Release'" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaSamplesVersion)" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaSamplesVersion)" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaSamplesVersion)" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Bogus" Version="34.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/TreeDataGridDemo/TreeDataGridDemo.csproj
+++ b/samples/TreeDataGridDemo/TreeDataGridDemo.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>False</IsPackable>
     <OutputType>WinExe</OutputType>
+    <PublishAot Condition="'$(Configuration)' == 'Release'">true</PublishAot>
   </PropertyGroup>
   <ItemGroup>
     <AvaloniaResource Include="Assets\**" />
@@ -12,12 +13,12 @@
     <None Remove="Assets\folder.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
+    <PackageReference Include="Avalonia" Version="$(AvaloniaSamplesVersion)" />
+    <PackageReference Include="Avalonia.Desktop" Version="$(AvaloniaSamplesVersion)" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="$(AvaloniaSamplesVersion)" Condition="'$(Configuration)' != 'Release'" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaSamplesVersion)" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="$(AvaloniaSamplesVersion)" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaSamplesVersion)" />
     <PackageReference Include="Bogus" Version="34.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/CountriesPageViewModel.cs
@@ -3,12 +3,12 @@ using System.Linq;
 using Avalonia.Controls;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
-using ReactiveUI;
+using CommunityToolkit.Mvvm.ComponentModel;
 using TreeDataGridDemo.Models;
 
 namespace TreeDataGridDemo.ViewModels
 {
-    internal class CountriesPageViewModel : ReactiveObject
+    internal class CountriesPageViewModel : ObservableObject
     {
         private readonly ObservableCollection<Country> _data;
         private bool _cellSelection;
@@ -50,7 +50,7 @@ namespace TreeDataGridDemo.ViewModels
                         Source.Selection = new TreeDataGridCellSelectionModel<Country>(Source) { SingleSelect = false };
                     else
                         Source.Selection = new TreeDataGridRowSelectionModel<Country>(Source) { SingleSelect = false };
-                    this.RaisePropertyChanged();
+                    OnPropertyChanged();
                 }
             }
         }

--- a/samples/TreeDataGridDemo/ViewModels/DragDropPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/DragDropPageViewModel.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.ObjectModel;
 using Avalonia.Controls;
 using Avalonia.Controls.Models.TreeDataGrid;
-using ReactiveUI;
+using CommunityToolkit.Mvvm.ComponentModel;
 using TreeDataGridDemo.Models;
 
 namespace TreeDataGridDemo.ViewModels
 {
-    internal class DragDropPageViewModel : ReactiveObject
+    internal class DragDropPageViewModel : ObservableObject
     {
         private ObservableCollection<DragDropItem> _data;
 

--- a/samples/TreeDataGridDemo/ViewModels/WikipediaPageViewModel.cs
+++ b/samples/TreeDataGridDemo/ViewModels/WikipediaPageViewModel.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Avalonia.Collections;
 using Avalonia.Controls;
@@ -11,7 +12,7 @@ using TreeDataGridDemo.Models;
 
 namespace TreeDataGridDemo.ViewModels
 {
-    internal class WikipediaPageViewModel
+    internal partial class WikipediaPageViewModel
     {
         private readonly AvaloniaList<OnThisDayArticle> _data = new();
 
@@ -47,15 +48,19 @@ namespace TreeDataGridDemo.ViewModels
                 var m = DateTimeOffset.Now.Month;
                 var uri = $"https://api.wikimedia.org/feed/v1/wikipedia/en/onthisday/all/{m}/{d}";
                 var s = await client.GetStringAsync(uri);
-                var data = JsonSerializer.Deserialize<OnThisDay>(s, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true,
-                });
+                var data = (OnThisDay)JsonSerializer.Deserialize(s, typeof(OnThisDay), SerializationContext.Default)!;
 
                 if (data?.Selected is not null)
                     _data.AddRange(data.Selected.SelectMany(x => x.Pages!));
             }
             catch { }
+        }
+
+        [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+        [JsonSerializable(typeof(OnThisDay))]
+        internal partial class SerializationContext : JsonSerializerContext
+        {
+            
         }
     }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
+++ b/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />
-    
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
+++ b/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>True</IsPackable>
     <RootNamespace>Avalonia.Controls</RootNamespace>
   </PropertyGroup>
@@ -12,4 +12,19 @@
 
     <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
+
+  <!-- Trimming -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+    <IsTrimmable>true</IsTrimmable>
+    <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <!-- AOT -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <IsAotCompatible Condition="'$(IsAotCompatible)' == ''">true</IsAotCompatible>
+  </PropertyGroup>
+
 </Project>

--- a/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
+++ b/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net8.0</TargetFrameworks>
     <IsPackable>True</IsPackable>
     <RootNamespace>Avalonia.Controls</RootNamespace>
   </PropertyGroup>

--- a/src/Avalonia.Controls.TreeDataGrid/Experimental/Data/Core/TypedBindingExpression`2.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Experimental/Data/Core/TypedBindingExpression`2.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Reactive.Subjects;
 using Avalonia.Data;
+using Avalonia.Reactive;
 using Avalonia.Utilities;
 
 #nullable enable
@@ -19,7 +19,7 @@ namespace Avalonia.Experimental.Data.Core
     /// instantiated on an object.
     /// </remarks>
     public class TypedBindingExpression<TIn, TOut> : LightweightObservableBase<BindingValue<TOut>>,
-        ISubject<BindingValue<TOut>>,
+        IObserver<BindingValue<TOut>>,
         IDescription
             where TIn : class
     {
@@ -91,7 +91,7 @@ namespace Avalonia.Experimental.Data.Core
         protected override void Initialize()
         {
             _flags &= ~Flags.RootHasFired;
-            _rootSourceSubsciption = _rootSource.Subscribe(RootChanged);
+            _rootSourceSubsciption = _rootSource.Subscribe(new AnonymousObserver<TIn?>(RootChanged));
             _flags |= Flags.Initialized;
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Experimental/Data/ObservableEx.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Experimental/Data/ObservableEx.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Reactive.Disposables;
+using Avalonia.Experimental.Data.Core;
 
 namespace Avalonia.Experimental.Data
 {

--- a/src/Avalonia.Controls.TreeDataGrid/Experimental/Data/TypedBinding`2.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Experimental/Data/TypedBinding`2.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reactive.Disposables;
 using Avalonia.Data;
 using Avalonia.Experimental.Data.Core;
 using Avalonia.Reactive;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/AnonymousRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/AnonymousRow.cs
@@ -15,10 +15,10 @@ namespace Avalonia.Controls.Models.TreeDataGrid
     internal class AnonymousRow<TModel> : IRow<TModel>, IModelIndexableRow
     {
         private int _modelIndex;
-        [AllowNull] private TModel _model;
+        private TModel? _model;
 
         public object? Header => _modelIndex;
-        public TModel Model => _model;
+        public TModel Model => _model!;
         public int ModelIndex => _modelIndex;
         public IndexPath ModelIndexPath => _modelIndex;
 

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxCell.cs
@@ -1,13 +1,12 @@
 ﻿using System;
-using System.Reactive.Subjects;
-using System.Reflection;
 using Avalonia.Data;
+using Avalonia.Reactive;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
     public class CheckBoxCell : NotifyingBase, ICell, IDisposable
     {
-        private readonly ISubject<BindingValue<bool?>>? _binding;
+        private readonly IObserver<BindingValue<bool?>>? _binding;
         private readonly IDisposable? _subscription;
         private bool? _value;
 
@@ -18,19 +17,29 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         }
 
         public CheckBoxCell(
-            ISubject<BindingValue<bool?>> binding,
+            IObserver<BindingValue<bool?>> bindingObserver,
+            IObservable<BindingValue<bool?>> bindingObservable,
             bool isReadOnly,
             bool isThreeState)
         {
-            _binding = binding;
+            _binding = bindingObserver;
             IsReadOnly = isReadOnly;
             IsThreeState = isThreeState;
 
-            _subscription = binding.Subscribe(x =>
+            _subscription = bindingObservable.Subscribe(new AnonymousObserver<BindingValue<bool?>>(x =>
             {
                 if (x.HasValue)
                     Value = x.Value;
-            });
+            }));
+        }
+
+        [Obsolete("ISubject<> might be removed in the future versions.")]
+        public CheckBoxCell(
+            System.Reactive.Subjects.ISubject<BindingValue<bool?>> binding,
+            bool isReadOnly,
+            bool isThreeState)
+            : this(binding, binding, isReadOnly, isThreeState)
+        {
         }
 
         public bool CanEdit => false;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/CheckBoxColumn.cs
@@ -68,7 +68,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
         public override ICell CreateCell(IRow<TModel> row)
         {
-            return new CheckBoxCell(CreateBindingExpression(row.Model), Binding.Write is null, IsThreeState);
+            var expression = CreateBindingExpression(row.Model);
+            return new CheckBoxCell(expression, expression, Binding.Write is null, IsThreeState);
         }
 
         private static Func<TModel, bool?> ToNullable(Expression<Func<TModel, bool>> getter)

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`2.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`2.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Linq.Expressions;
 using Avalonia.Experimental.Data;
 using Avalonia.Experimental.Data.Core;
-using Avalonia.Reactive;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextCell.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Reactive.Subjects;
 using Avalonia.Data;
 using Avalonia.Media;
+using Avalonia.Reactive;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
     public class TextCell<T> : NotifyingBase, ITextCell, IDisposable, IEditableObject
     {
-        private readonly ISubject<BindingValue<T>>? _binding;
+        private readonly IObserver<BindingValue<T>>? _binding;
         private readonly ITextCellOptions? _options;
         private readonly IDisposable? _subscription;
         private string? _editText;
@@ -23,19 +24,29 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         }
 
         public TextCell(
-            ISubject<BindingValue<T>> binding,
+            IObserver<BindingValue<T>> bindingSubject,
+            IObservable<BindingValue<T>> bindingObservable,
             bool isReadOnly,
             ITextCellOptions? options = null)
         {
-            _binding = binding;
+            _binding = bindingSubject;
             IsReadOnly = isReadOnly;
             _options = options;
 
-            _subscription = binding.Subscribe(x =>
+            _subscription = bindingObservable.Subscribe(new AnonymousObserver<BindingValue<T>>(x =>
             {
                 if (x.HasValue)
                     Value = x.Value;
-            });
+            }));
+        }
+
+        [Obsolete("ISubject<> might be removed in the future versions.")]
+        public TextCell(
+            System.Reactive.Subjects.ISubject<BindingValue<T>> binding,
+            bool isReadOnly,
+            ITextCellOptions? options = null)
+            : this(binding, binding, isReadOnly, options)
+        {
         }
 
         public bool CanEdit => !IsReadOnly;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumn.cs
@@ -62,7 +62,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
 
         public override ICell CreateCell(IRow<TModel> row)
         {
-            return new TextCell<TValue?>(CreateBindingExpression(row.Model), Binding.Write is null, Options);
+            var expression = CreateBindingExpression(row.Model);
+            return new TextCell<TValue?>(expression, expression, Binding.Write is null, Options);
         }
 
         string? ITextSearchableColumn<TModel>.SelectValue(TModel model)

--- a/src/Avalonia.Controls.TreeDataGrid/Utils/CompositeDisposable.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Utils/CompositeDisposable.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Avalonia;
+
+internal class CompositeDisposable : IDisposable
+{
+    private readonly IDisposable _disposable1;
+    private readonly IDisposable _disposable2;
+
+    public CompositeDisposable(IDisposable disposable1, IDisposable disposable2)
+    {
+        _disposable1 = disposable1;
+        _disposable2 = disposable2;
+    }
+
+    public void Dispose()
+    {
+        _disposable1.Dispose();
+        _disposable2.Dispose();
+    }
+}

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
@@ -18,7 +18,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Value_Is_Initially_Read_From_String()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, true);
+            var target = new TextCell<string>(binding, binding, true);
 
             Assert.Equal("initial", target.Text);
             Assert.Equal("initial", target.Value);
@@ -28,7 +28,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Modified_Value_Is_Written_To_Binding()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, false);
+            var target = new TextCell<string>(binding, binding, false);
             var result = new List<string>();
 
             binding.Subscribe(x => result.Add(x.Value));
@@ -41,7 +41,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Modified_Text_Is_Written_To_Binding()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, false);
+            var target = new TextCell<string>(binding, binding, false);
             var result = new List<string>();
 
             binding.Subscribe(x => result.Add(x.Value));
@@ -54,7 +54,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Modified_Value_Is_Written_To_Binding_On_EndEdit()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, false);
+            var target = new TextCell<string>(binding, binding, false);
             var result = new List<string>();
 
             binding.Subscribe(x => result.Add(x.Value));
@@ -77,7 +77,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
         public void Modified_Value_Is_Not_Written_To_Binding_On_CancelEdit()
         {
             var binding = new BehaviorSubject<BindingValue<string>>("initial");
-            var target = new TextCell<string>(binding, false);
+            var target = new TextCell<string>(binding, binding, false);
             var result = new List<string>();
 
             binding.Subscribe(x => result.Add(x.Value));


### PR DESCRIPTION
1. Adds .NET 6 and .NET 8 targets with corresponding Trimming and AOT warnings and attributes enabled.
2. Removed usage of System.Reactive everywhere but kept in the public API. This way it is trimmed away, if not used by the developers. 
3. Makes sample project completely AOT friendly (CommunityToolkit + JSON source gen + compiled bindings).

There are some minor breaking changes in the `Avalonia.Experimental.Data` namespace, but it's not a documented user API at least. Apps that already use TreeDataGrid should be unaffected unless they used experimental APIs directly.

System.Linq.Expressions is still widely used in the project. We might want to avoid that in the future. It doesn't produce trimming warnings here at least.