### PR TITLE
Handle focused item being removed when outside the viewport.

### DIFF
--- a/samples/TreeDataGridDemo/App.axaml.cs
+++ b/samples/TreeDataGridDemo/App.axaml.cs
@@ -9,6 +9,7 @@ namespace TreeDataGridDemo
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
+            Bogus.Randomizer.Seed = new System.Random(0);
         }
 
         public override void OnFrameworkInitializationCompleted()

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -729,6 +729,8 @@ namespace Avalonia.Controls.Primitives
                     break;
                 case NotifyCollectionChangedAction.Reset:
                     _realizedElements.ItemsReset(_recycleElementOnItemRemoved);
+                    if (_focusedElement is not null )
+                        RecycleElementOnItemRemoved(_focusedElement);
                     break;
             }
         }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridRowsPresenterTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Primitives/TreeDataGridRowsPresenterTests.cs
@@ -353,6 +353,78 @@ namespace Avalonia.Controls.TreeDataGridTests.Primitives
         }
 
         [AvaloniaFact(Timeout = 10000)]
+        public void Handles_Removing_Focused_Row_While_Outside_Viewport()
+        {
+            var (target, scroll, items) = CreateTarget();
+            var element = target.RealizedElements.ElementAt(0)!;
+
+            element.Focusable = true;
+            element.Focus();
+
+            // Scroll down one item.
+            scroll.Offset = new Vector(0, 10);
+            Layout(target);
+
+            // Remove the focused element.
+            items.RemoveAt(0);
+
+            // Scroll back to the beginning.
+            scroll.Offset = new Vector(0, 0);
+            Layout(target);
+
+            // The correct element should be shown.
+            Assert.Same(items[0], target.RealizedElements.ElementAt(0)!.DataContext);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Handles_Replacing_Focused_Row_While_Outside_Viewport()
+        {
+            var (target, scroll, items) = CreateTarget();
+            var element = target.RealizedElements.ElementAt(0)!;
+
+            element.Focusable = true;
+            element.Focus();
+
+            // Scroll down one item.
+            scroll.Offset = new Vector(0, 10);
+            Layout(target);
+
+            // Replace the focused element.
+            items[0] = new Model { Id = 100, Title = "New Item" };
+
+            // Scroll back to the beginning.
+            scroll.Offset = new Vector(0, 0);
+            Layout(target);
+
+            // The correct element should be shown.
+            Assert.Same(items[0], target.RealizedElements.ElementAt(0)!.DataContext);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Handles_Moving_Focused_Row_While_Outside_Viewport()
+        {
+            var (target, scroll, items) = CreateTarget();
+            var element = target.RealizedElements.ElementAt(0)!;
+
+            element.Focusable = true;
+            element.Focus();
+
+            // Scroll down one item.
+            scroll.Offset = new Vector(0, 10);
+            Layout(target);
+
+            // Move the focused element.
+            items.Move(0, items.Count - 1);
+
+            // Scroll back to the beginning.
+            scroll.Offset = new Vector(0, 0);
+            Layout(target);
+
+            // The correct element should be shown.
+            Assert.Same(items[0], target.RealizedElements.ElementAt(0)!.DataContext);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
         public void Updates_Star_Column_ActualWidth()
         {
             var columns = new ColumnList<Model>


### PR DESCRIPTION
When the focused container is scrolled outside the viewport and the corresponding row is removed, then the focused container needs to be recycled.

This was manifesting itself in drag/drop appearing to not work correctly in conjunction with scrolling:

https://github.com/user-attachments/assets/fbad422d-7c7d-409a-8f8e-59e0da993dee

