### PR TITLE
DnD: Reset mouse down location

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -167,6 +167,18 @@ namespace Avalonia.Controls.Primitives
             owner?.RaiseRowDragStarted(e);
         }
 
+        protected override void OnPointerReleased(PointerReleasedEventArgs e)
+        {
+            base.OnPointerReleased(e);
+            _mouseDownPosition = s_InvalidPoint;
+        }
+
+        protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+        {
+            base.OnPointerCaptureLost(e);
+            _mouseDownPosition = s_InvalidPoint;
+        }
+
         protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
         {
             if (change.Property == IsSelectedProperty)


### PR DESCRIPTION
Reset mouse down location on pointer release or capture lost. Fixes an issue with phantom drags occurring on macOS due to https://github.com/AvaloniaUI/Avalonia/issues/16936