### PR TITLE
Allow Columns to be modified / re-ordered for HierarchicalDataSources

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -358,8 +358,6 @@ namespace Avalonia.Controls
                         }
                     }
                     break;
-                default:
-                    throw new NotImplementedException();
             }
         }
     }

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -367,8 +367,6 @@ namespace Avalonia.Controls
                     {
                         throw new InvalidOperationException("The expander column cannot be removed by a reset.");
                     }
-
-                    _expanderColumn = null; // Optionally clear the expander column
                     break;
 
                 default:

--- a/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/HierarchicalTreeDataGridSource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -346,18 +347,66 @@ namespace Avalonia.Controls
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
-                    if (_expanderColumn is null && e.NewItems is object)
-                    {
-                        foreach (var i in e.NewItems)
-                        {
-                            if (i is IExpanderColumn<TModel> expander)
-                            {
-                                _expanderColumn = expander;
-                                break;
-                            }
-                        }
-                    }
+                    HandleAdd(e.NewItems);
                     break;
+
+                case NotifyCollectionChangedAction.Remove:
+                    HandleRemoveReplaceOrMove(e.OldItems, "removed");
+                    break;
+
+                case NotifyCollectionChangedAction.Replace:
+                    HandleRemoveReplaceOrMove(e.NewItems, "replaced");
+                    break;
+
+                case NotifyCollectionChangedAction.Move:
+                    HandleRemoveReplaceOrMove(e.NewItems, "moved");
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    if (_expanderColumn is not null)
+                    {
+                        throw new InvalidOperationException("The expander column cannot be removed by a reset.");
+                    }
+
+                    _expanderColumn = null; // Optionally clear the expander column
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        private void HandleAdd(IList? newItems)
+        {
+            if (newItems is not null)
+            {
+                foreach (var i in newItems)
+                {
+                    if (i is IExpanderColumn<TModel> expander)
+                    {
+                        if (_expanderColumn is not null)
+                        {
+                            throw new InvalidOperationException("Only one expander column is allowed.");
+                        }
+
+                        _expanderColumn = expander;
+                        break;
+                    }
+                }
+            }
+        }
+
+        private void HandleRemoveReplaceOrMove(IList? items, string action)
+        {
+            if (items is not null)
+            {
+                foreach (var i in items)
+                {
+                    if (i is IExpanderColumn<TModel> && _expanderColumn is not null)
+                    {
+                        throw new InvalidOperationException($"The expander column cannot be {action}.");
+                    }
+                }
             }
         }
     }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/HierarchicalTreeDataGridSourceTests.cs
@@ -491,6 +491,36 @@ namespace Avalonia.Controls.TreeDataGridTests
             }
         }
 
+        [AvaloniaFact(Timeout = 10000)]
+        public void Adding_Second_Expander_Column_Throws()
+        {
+            var data = CreateData();
+            var target = CreateTarget(data, false);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                target.Columns.Add(new HierarchicalExpanderColumn<Node>(
+                    new TextColumn<Node, int>("ID", x => x.Id),
+                    x => x.Children,
+                    null,
+                    x => x.IsExpanded));
+            });
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Removing_Expander_Column_Throws()
+        {
+            var data = CreateData();
+            var target = CreateTarget(data, false);
+
+            var expander = target.Columns.OfType<IExpanderColumn<Node>>().First();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                target.Columns.Remove(expander);
+            });
+        }
+
         public class ExpansionBinding
         {
             [AvaloniaFact(Timeout = 10000)]


### PR DESCRIPTION
HierarchicalTreeDataGridSource handles OnColumnsCollectionChanged to grab a reference to the expander columns.

However it throws NotImplementException for all actions other than Add, this prevents the user from re-ordering the columns at runtime.

It currently works for Flat sources, but this minor bug prevents it from working for Hierarchical sources.

How the fix works:

simply no need to throw NotImplementedException here.