### PR TITLE
If the user modifies the ColumnList ensure the TreeDataColumnHeader.ColumnIndex is kept in sync

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnHeader.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnHeader.cs
@@ -65,6 +65,11 @@ namespace Avalonia.Controls.Primitives
                 newInpc.PropertyChanged += OnModelPropertyChanged;
         }
 
+        public void UpdateColumnIndex(int columnIndex)
+        {
+            ColumnIndex = columnIndex;
+        }
+
         public void Unrealize()
         {
             if (_model is INotifyPropertyChanged oldInpc)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnHeadersPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnHeadersPresenter.cs
@@ -33,6 +33,7 @@ namespace Avalonia.Controls.Primitives
 
         protected override void UpdateElementIndex(Control element, int oldIndex, int newIndex)
         {
+            ((TreeDataGridColumnHeader)element).UpdateColumnIndex(newIndex);
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, newIndex));
         }
 

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
@@ -313,6 +313,35 @@ namespace Avalonia.Controls.TreeDataGridTests
         }
 
         [AvaloniaFact(Timeout = 10000)]
+        public void Header_Column_Indexes_Are_Updated_When_Columns_Are_Updated()
+        {
+            var (target, items) = CreateTarget(columns: new IColumn<Model>[]
+            {
+                new TextColumn<Model, int>("ID", x => x.Id, width: new GridLength(1, GridUnitType.Star)),
+                new TextColumn<Model, string?>("Title1", x => x.Title,  width: new GridLength(1, GridUnitType.Star)),
+                new TextColumn<Model, string?>("Title2", x => x.Title,  width: new GridLength(1, GridUnitType.Star)),
+                new TextColumn<Model, string?>("Title3", x => x.Title,  width: new GridLength(1, GridUnitType.Star)),
+            });
+
+            AssertColumnIndexes(target, 0, 4);
+
+            var source =(FlatTreeDataGridSource<Model>)target.Source!;
+
+            var movedColumn = source.Columns[1];
+            source.Columns.Remove(movedColumn);
+
+            AssertColumnIndexes(target, 0, 3);
+
+            source.Columns.Add(movedColumn);
+
+            var root = (TestWindow)target.GetVisualRoot()!;
+            root.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            AssertColumnIndexes(target, 0, 4);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
         public void Columns_Are_Correctly_Sized_After_Changing_Source()
         {
             // Create the initial target with 2 columns and make sure our preconditions are correct.


### PR DESCRIPTION
Currently changing the column order breaks the sorting, because the columnheaders ColumnIndex is still pointing to the old arrangement.

- Add a failing unit test.
- Fix it by updating the ColumnIndex.

