### PR TITLE
Fix layout bug: InvalidateMeasure the parent container as a recycled element is placed into it

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridElementFactory.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridElementFactory.cs
@@ -22,6 +22,7 @@ namespace Avalonia.Controls.Primitives
 
                     if (e.Parent == parent)
                     {
+                        parent.InvalidateMeasure();
                         elements.RemoveAt(i);
                         return e;
                     }
@@ -35,6 +36,7 @@ namespace Avalonia.Controls.Primitives
 
                     if (e.Parent is null || parentPanel is not null)
                     {
+                        parent.InvalidateMeasure();
                         parentPanel?.Children.Remove(e);
                         Debug.Assert(e.Parent is null);
                         elements.RemoveAt(i);


### PR DESCRIPTION
Imagine the datasource is reconfigured, causing the same elements to be displayed but they can end up different sizes.

(i.e. having a tree with children, then moving to a flat layout)

when you go from one layout to the next, the recycled cells may now have a different size, except they do not get re-measured / arranged (I assume for performance issues?)

This can cause many many layout issues that I have seen in various projects that use this.

This fix, invalidates the parent container, only if an item is being recycled.

I couldnt detect any noticable performance degradation in my app or in the sample app.

This fix is a catch all solution, and will get rid of the bug in all scenarios (I expect)

Another approach, might be to clear the cache of recycled elements if the datasource is changed.
(this would possibly fix my use case, but I know of other people who have this issue and it would not fix the issue for them)