### PR TITLE
Add StringFormat option to text cells.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCell.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Media;
+﻿using System.Globalization;
+
+using Avalonia.Media;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
@@ -21,7 +23,8 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// Gets the cell's text wrapping mode.
         /// </summary>
         TextWrapping TextWrapping { get; }
-        
+
+        /// <summary>
         /// Gets the cell's text alignment mode.
         /// </summary>
         TextAlignment TextAlignment { get; }

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCellOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ITextCellOptions.cs
@@ -1,9 +1,21 @@
-﻿using Avalonia.Media;
+﻿using System.Globalization;
+
+using Avalonia.Media;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
     public interface ITextCellOptions : ICellOptions
     {
+        /// <summary>
+        /// Gets the format string to be used to format the cell value.
+        /// </summary>
+        string StringFormat { get; }
+
+        /// <summary>
+        /// Gets the culture to be used in conjunction with <see cref="StringFormat"/>.
+        /// </summary>
+        CultureInfo Culture { get; }
+
         /// <summary>
         /// Gets the text trimming mode for the cell.
         /// </summary>

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/TextColumnOptions.cs
@@ -1,4 +1,6 @@
-﻿using Avalonia.Media;
+﻿using System.Globalization;
+
+using Avalonia.Media;
 
 namespace Avalonia.Controls.Models.TreeDataGrid
 {
@@ -12,6 +14,16 @@ namespace Avalonia.Controls.Models.TreeDataGrid
         /// Gets or sets a value indicating whether the column takes part in text searches.
         /// </summary>
         public bool IsTextSearchEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the format string for the cells in the column.
+        /// </summary>
+        public string StringFormat { get; set; } = "{0}";
+
+        /// <summary>
+        /// Culture info used in conjunction with <see cref="StringFormat"/>
+        /// </summary>
+        public CultureInfo Culture { get; set; } = CultureInfo.CurrentCulture;
 
         /// <summary>
         /// Gets or sets the text trimming mode for the cells in the column.

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -93,7 +93,10 @@ namespace Avalonia.Controls.Primitives
         protected void EndEdit()
         {
             if (EndEditCore() && Model is IEditableObject editable)
+            {
                 editable.EndEdit();
+                UpdateValue();
+            }
         }
 
         protected void SubscribeToModelChanges()
@@ -106,6 +109,10 @@ namespace Avalonia.Controls.Primitives
         {
             if (Model is INotifyPropertyChanged inpc)
                 inpc.PropertyChanged -= OnModelPropertyChanged;
+        }
+
+        protected virtual void UpdateValue()
+        {
         }
 
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
-using Avalonia.Input;
-using Avalonia.Interactivity;
 using Avalonia.Media;
 
 namespace Avalonia.Controls.Primitives
@@ -64,6 +64,7 @@ namespace Avalonia.Controls.Primitives
             get => _textAlignment;
             set => SetAndRaise(TextAlignmentProperty, ref _textAlignment, value);
         }
+
         public override void Realize(
             TreeDataGridElementFactory factory,
             ITreeDataGridSelectionInteraction? selection,
@@ -71,7 +72,7 @@ namespace Avalonia.Controls.Primitives
             int columnIndex,
             int rowIndex)
         {
-            Value = model.Value?.ToString();
+            Value = (model as ITextCell)?.Text;
             TextTrimming = (model as ITextCell)?.TextTrimming ?? TextTrimming.CharacterEllipsis;
             TextWrapping = (model as ITextCell)?.TextWrapping ?? TextWrapping.NoWrap;
             TextAlignment = (model as ITextCell)?.TextAlignment ?? TextAlignment.Left;
@@ -83,6 +84,11 @@ namespace Avalonia.Controls.Primitives
         {
             UnsubscribeFromModelChanges();
             base.Unrealize();
+        }
+
+        protected override void UpdateValue()
+        {
+            Value = (Model as ITextCell)?.Text;
         }
 
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Models/TextCellTests.cs
@@ -63,7 +63,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
             target.Text = "new";
 
             Assert.Equal("new", target.Text);
-            Assert.Equal("new", target.Value);
+            Assert.Equal("initial", target.Value);
             Assert.Equal(new[] { "initial"}, result);
 
             target.EndEdit();
@@ -86,7 +86,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
             target.Text = "new";
 
             Assert.Equal("new", target.Text);
-            Assert.Equal("new", target.Value);
+            Assert.Equal("initial", target.Value);
             Assert.Equal(new[] { "initial" }, result);
 
             target.CancelEdit();
@@ -94,6 +94,47 @@ namespace Avalonia.Controls.TreeDataGridTests.Models
             Assert.Equal("initial", target.Text);
             Assert.Equal("initial", target.Value);
             Assert.Equal(new[] { "initial" }, result);
+        }
+
+        public class StringFormat
+        {
+            [AvaloniaFact(Timeout = 10000)]
+            public void Initial_Int_Value_Is_Formatted()
+            {
+                var binding = new BehaviorSubject<BindingValue<int>>(42);
+                var target = new TextCell<int>(binding, true, GetOptions());
+
+                Assert.Equal("42.00", target.Text);
+                Assert.Equal(42, target.Value);
+            }
+
+            [AvaloniaFact(Timeout = 10000)]
+            public void Int_Value_Is_Formatted_After_Editing()
+            {
+                var binding = new BehaviorSubject<BindingValue<int>>(42);
+                var target = new TextCell<int>(binding, false, GetOptions());
+                var result = new List<int>();
+
+                binding.Subscribe(x => result.Add(x.Value));
+
+                target.BeginEdit();
+                target.Text = "43";
+
+                Assert.Equal("43", target.Text);
+                Assert.Equal(42, target.Value);
+                Assert.Equal(new[] { 42 }, result);
+
+                target.EndEdit();
+
+                Assert.Equal("43.00", target.Text);
+                Assert.Equal(43, target.Value);
+                Assert.Equal(new[] { 42, 43 }, result);
+            }
+
+            private ITextCellOptions? GetOptions(string format = "{0:n2}")
+            {
+                return new TextColumnOptions<int> { StringFormat = format };
+            }
         }
     }
 }


### PR DESCRIPTION
This is similar to #283, but I used a slightly difference approach as the feature in that PR caused problems when text cells were edited.

The differences are:

- The formatting is done in the TDG model layer (`TextCell`) rather than in the view layer (`TreeDataGridTextCell`) - this allows us to keep the edited text and the underlying value separate. This prevents the exception when editing.
- The value is now only written to the bound model when editing ends. This prevents exceptions while editing the value (previously worked around in #276 
- The default culture is now `CurrentCulture` rather than `InvariantCuture`. [This aligns with standard Avalonia bindings](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Base/Data/Core/BindingExpression.cs#L141)