### PR TITLE
Don't write value to model when change comes from model.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
@@ -33,6 +33,7 @@ namespace Avalonia.Controls.Primitives
 
         private string? _value;
         private TextBox? _edit;
+        private bool _modelValueChanging;
         private TextTrimming _textTrimming = TextTrimming.CharacterEllipsis;
         private TextWrapping _textWrapping = TextWrapping.NoWrap;
         private TextAlignment _textAlignment = TextAlignment.Left;
@@ -54,7 +55,7 @@ namespace Avalonia.Controls.Primitives
             get => _value;
             set
             {
-                if (SetAndRaise(ValueProperty, ref _value, value) && Model is ITextCell cell)
+                if (SetAndRaise(ValueProperty, ref _value, value) && Model is ITextCell cell && !_modelValueChanging)
                     cell.Text = _value;
             }
         }
@@ -109,7 +110,17 @@ namespace Avalonia.Controls.Primitives
             base.OnModelPropertyChanged(sender, e);
 
             if (e.PropertyName == nameof(ITextCell.Value))
-                Value = Model?.Value?.ToString();
+            {
+                try
+                {
+                    _modelValueChanging = true;
+                    Value = Model?.Value?.ToString();
+                }
+                finally
+                {
+                    _modelValueChanging = false;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
If a changed value comes from the model, then we shouldn't be writing it back to the model. Usually this would be a no-op but when a `StringFormat` is applied it causes the formatted value to be sent back to the underlying data model, and if the `StringFormat` is not round-trippable causes an exception.