### PR TITLE
Handle Move in TreeSelectionMode.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           dotnet-version: | 
             6.0.x
-            7.0.x
+            8.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>12</LangVersion>
     <!-- https://github.com/dotnet/msbuild/issues/2661 -->
     <AddSyntheticProjectReferencesForSolutionDependencies>false</AddSyntheticProjectReferencesForSolutionDependencies>
     <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.101",
+    "version": "8.0.101",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
+++ b/src/Avalonia.Controls.TreeDataGrid/Avalonia.Controls.TreeDataGrid.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <IsPackable>True</IsPackable>
-    <LangVersion>10</LangVersion>
     <RootNamespace>Avalonia.Controls</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/IndexRange.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/IndexRange.cs
@@ -275,13 +275,13 @@ namespace Avalonia.Controls.Selection
         public static int Remove(
             IList<IndexRange> destination,
             IReadOnlyList<IndexRange> source,
-            IList<IndexRange>? added = null)
+            IList<IndexRange>? removed = null)
         {
             var result = 0;
 
             foreach (var range in source)
             {
-                result += Remove(destination, range, added);
+                result += Remove(destination, range, removed);
             }
 
             return result;

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/SelectionNodeBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/SelectionNodeBase.cs
@@ -2,6 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Reflection;
+using System.Threading.Channels;
 using Avalonia.Controls.Utils;
 
 #nullable enable
@@ -243,7 +245,7 @@ namespace Avalonia.Controls.Selection
         /// assigning new indexes. Override this method to carry out additional computation when
         /// items are added.
         /// </remarks>
-        protected virtual CollectionChangeState OnItemsAdded(int index, IList items)
+        private protected CollectionChangeState OnItemsAdded(int index, IList items)
         {
             var count = items.Count;
             var shifted = false;
@@ -305,7 +307,7 @@ namespace Avalonia.Controls.Selection
         /// assigning new indexes. Override this method to carry out additional computation when
         /// items are removed.
         /// </remarks>
-        private protected virtual CollectionChangeState OnItemsRemoved(int index, IList items)
+        private protected CollectionChangeState OnItemsRemoved(int index, IList items)
         {
             var count = items.Count;
             var removedRange = new IndexRange(index, index + count - 1);
@@ -349,10 +351,58 @@ namespace Avalonia.Controls.Selection
             };
         }
 
+        private protected IReadOnlyList<CollectionChangeState> OnItemsMoved(
+            int oldIndex,
+            int newIndex,
+            int count)
+        {
+            var selectedItemsMoved = false;
+            var unselectedItemsMoved = false;
+
+            if (_ranges is not null)
+            {
+                var removedRange = new IndexRange(oldIndex, oldIndex + count - 1);
+                var movedRanges = new List<IndexRange>();
+
+                if (IndexRange.Remove(_ranges, removedRange, movedRanges) > 0)
+                {
+                    foreach (var range in movedRanges)
+                    {
+                        var insertRange = new IndexRange(
+                            range.Begin + (newIndex - oldIndex),
+                            range.End + (newIndex - oldIndex));
+                        IndexRange.Add(_ranges, insertRange);
+                        selectedItemsMoved = true;
+                    }
+                }
+
+                for (var i = 0; i < Ranges!.Count; ++i)
+                {
+                    var existing = Ranges[i];
+
+                    if (existing.Begin >= oldIndex && existing.End < newIndex)
+                    {
+                        _ranges[i] = new IndexRange(existing.Begin - count, existing.End - count);
+                        unselectedItemsMoved = true;
+                    }
+                }
+            }
+
+            if (selectedItemsMoved || unselectedItemsMoved)
+            {
+                var changes = new List<CollectionChangeState>();
+                return changes;
+            }
+            else
+            {
+                return [];
+            }
+        }
+
         /// <summary>
         /// Details the results of a collection change on the current selection;
         /// </summary>
-        protected class CollectionChangeState
+        private protected class CollectionChangeState
         {
             /// <summary>
             /// Gets or sets the first index that was shifted as a result of the collection

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/SelectionNodeBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/SelectionNodeBase.cs
@@ -2,8 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Reflection;
-using System.Threading.Channels;
 using Avalonia.Controls.Utils;
 
 #nullable enable

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
@@ -340,6 +340,13 @@ namespace Avalonia.Controls.Selection
                 selectedIndexChanged = selectedItemChanged = true;
             }
 
+            // If the anchor index is invalid, clear it.
+            if (_anchorIndex != default && !TryGetItemAt(_anchorIndex, out _))
+            {
+                _anchorIndex = default;
+                anchorIndexChanged = true;
+            }
+
             Count -= removeCount;
             SourceReset?.Invoke(this, new TreeSelectionModelSourceResetEventArgs(parentIndex));
 

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelBase.cs
@@ -271,7 +271,8 @@ namespace Avalonia.Controls.Selection
 
         internal void OnNodeCollectionChanged(
             IndexPath parentIndex,
-            int shiftIndex,
+            int shiftStartIndex,
+            int shiftEndIndex,
             int shiftDelta,
             bool raiseIndexesChanged,
             IReadOnlyList<T?>? removed)
@@ -285,13 +286,13 @@ namespace Avalonia.Controls.Selection
             {
                 IndexesChanged?.Invoke(
                     this,
-                    new TreeSelectionModelIndexesChangedEventArgs(parentIndex, shiftIndex, shiftDelta));
+                    new TreeSelectionModelIndexesChangedEventArgs(parentIndex, shiftStartIndex, shiftEndIndex, shiftDelta));
             }
 
             // Shift or clear the selected and anchor indexes according to the shift index/delta.
             var hadSelection = _selectedIndex != default;
-            var selectedIndexChanged = ShiftIndex(parentIndex, shiftIndex, shiftDelta, ref _selectedIndex);
-            var anchorIndexChanged = ShiftIndex(parentIndex, shiftIndex, shiftDelta, ref _anchorIndex);
+            var selectedIndexChanged = ShiftIndex(parentIndex, shiftStartIndex, shiftDelta, ref _selectedIndex);
+            var anchorIndexChanged = ShiftIndex(parentIndex, shiftStartIndex, shiftDelta, ref _anchorIndex);
             var selectedItemChanged = false;
 
             // Check that the selected index is still selected in the node. It can get

--- a/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelIndexesChangedEventArgs.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Selection/TreeSelectionModelIndexesChangedEventArgs.cs
@@ -2,17 +2,41 @@
 
 namespace Avalonia.Controls.Selection
 {
+    /// <summary>
+    /// Holds data for the <see cref="ITreeSelectionModel.IndexesChanged"/> event.
+    /// </summary>
     public class TreeSelectionModelIndexesChangedEventArgs : EventArgs
     {
-        public TreeSelectionModelIndexesChangedEventArgs(IndexPath parentIndex, int startIndex, int delta)
+        public TreeSelectionModelIndexesChangedEventArgs(
+            IndexPath parentIndex,
+            int startIndex,
+            int endIndex,
+            int delta)
         {
             ParentIndex = parentIndex;
             StartIndex = startIndex;
+            EndIndex = endIndex;
             Delta = delta;
         }
 
+        /// <summary>
+        /// Gets the index of the parent item.
+        /// </summary>
         public IndexPath ParentIndex { get; }
+
+        /// <summary>
+        /// Gets the inclusive start index of the range of indexes that changed.
+        /// </summary>
         public int StartIndex { get; }
+
+        /// <summary>
+        /// Gets the exclusive end index of the range of indexes that changed.
+        /// </summary>
+        public int EndIndex { get; }
+
+        /// <summary>
+        /// Gets the delta of the change; i.e. the number of indexes added or removed.
+        /// </summary>
         public int Delta { get; }
     }
 }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Multiple.cs
@@ -1517,7 +1517,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 var target = CreateTarget(data);
                 var selectionChangedRaised = 0;
                 var sourceResetRaised = 0;
-                var indexesChangedraised = 0;
+                var indexesChangedRaised = 0;
 
                 target.Select(new IndexPath(0, 1));
                 target.Select(new IndexPath(0, 1, 0));
@@ -1528,7 +1528,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
 
                 target.SelectionChanged += (s, e) => ++selectionChangedRaised;
                 target.SourceReset += (s, e) => ++sourceResetRaised;
-                target.IndexesChanged += (s, e) => ++indexesChangedraised;
+                target.IndexesChanged += (s, e) => ++indexesChangedRaised;
 
                 data[0].Children!.Clear();
 
@@ -1538,7 +1538,7 @@ namespace Avalonia.Controls.TreeDataGridTests.Selection
                 Assert.Equal("Node 1-3", target.SelectedItem!.Caption);
                 Assert.Equal(new[] { "Node 1-3" }, target.SelectedItems.Select(x => x!.Caption));
                 Assert.Equal(new IndexPath(1, 3), target.AnchorIndex);
-                Assert.Equal(0, indexesChangedraised);
+                Assert.Equal(0, indexesChangedRaised);
                 Assert.Equal(0, selectionChangedRaised);
                 Assert.Equal(1, sourceResetRaised);
             }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
@@ -1170,7 +1170,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                 Assert.Equal(1, selectedIndexRaised);
                 Assert.Equal(1, selectedItemRaised);
             }
-#if false
+
             [AvaloniaFact(Timeout = 10000)]
             public void Resetting_Root_Updates_State()
             {
@@ -1178,7 +1178,6 @@ namespace Avalonia.Controls.TreeDataGridTests
                 var target = CreateTarget(data);
                 var selectionChangedRaised = 0;
                 var selectedIndexRaised = 0;
-                var resetRaised = 0;
 
                 target.Select(new IndexPath(1));
 
@@ -1200,10 +1199,9 @@ namespace Avalonia.Controls.TreeDataGridTests
                 Assert.Empty(target.SelectedItems);
                 Assert.Equal(default, target.AnchorIndex);
                 Assert.Equal(0, selectionChangedRaised);
-                Assert.Equal(1, resetRaised);
                 Assert.Equal(1, selectedIndexRaised);
             }
-#endif
+
             [AvaloniaFact(Timeout = 10000)]
             public void Handles_Selection_Made_In_CollectionChanged()
             {

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/Selection/TreeSelectionModelBaseTests_Single.cs
@@ -1172,6 +1172,207 @@ namespace Avalonia.Controls.TreeDataGridTests
             }
 
             [AvaloniaFact(Timeout = 10000)]
+            public void Moving_Selected_Root_Item_Updates_State()
+            {
+                var data = CreateData();
+                var target = CreateTarget(data);
+                var indexesChangedRaised = 0;
+                var selectionChangedRaised = 0;
+                var selectedIndexRaised = 0;
+                var selectedItemRaised = 0;
+
+                target.Select(new IndexPath(1));
+
+                target.IndexesChanged += (s, e) =>
+                {
+                    ++indexesChangedRaised;
+                };
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.SelectedIndex))
+                    {
+                        ++selectedIndexRaised;
+                    }
+
+                    if (e.PropertyName == nameof(target.SelectedItem))
+                    {
+                        ++selectedItemRaised;
+                    }
+                };
+
+                target.SelectionChanged += (s, e) =>
+                {
+                    ++selectionChangedRaised;
+                };
+
+                data.Move(1, 3);
+
+                Assert.Equal(0, target.Count);
+                Assert.Equal(default, target.SelectedIndex);
+                Assert.Empty(target.SelectedIndexes);
+                Assert.Null(target.SelectedItem);
+                Assert.Empty(target.SelectedItems);
+                Assert.Equal(1, indexesChangedRaised);
+                Assert.Equal(1, selectionChangedRaised);
+                Assert.Equal(1, selectedIndexRaised);
+                Assert.Equal(1, selectedItemRaised);
+            }
+
+            [AvaloniaFact(Timeout = 10000)]
+            public void Moving_Selected_Child_Item_Updates_State()
+            {
+                var data = CreateData();
+                var target = CreateTarget(data);
+                var indexesChangedRaised = 0;
+                var selectionChangedRaised = 0;
+                var selectedIndexRaised = 0;
+                var selectedItemRaised = 0;
+
+                target.Select(new IndexPath(1, 1));
+
+                target.IndexesChanged += (s, e) =>
+                {
+                    ++indexesChangedRaised;
+                };
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.SelectedIndex))
+                    {
+                        ++selectedIndexRaised;
+                    }
+
+                    if (e.PropertyName == nameof(target.SelectedItem))
+                    {
+                        ++selectedItemRaised;
+                    }
+                };
+
+                target.SelectionChanged += (s, e) =>
+                {
+                    ++selectionChangedRaised;
+                };
+
+                data[1].Children!.Move(1, 2);
+
+                Assert.Equal(0, target.Count);
+                Assert.Equal(default, target.SelectedIndex);
+                Assert.Empty(target.SelectedIndexes);
+                Assert.Null(target.SelectedItem);
+                Assert.Empty(target.SelectedItems);
+                Assert.Equal(1, indexesChangedRaised);
+                Assert.Equal(1, selectionChangedRaised);
+                Assert.Equal(1, selectedIndexRaised);
+                Assert.Equal(1, selectedItemRaised);
+            }
+
+            [AvaloniaFact(Timeout = 10000)]
+            public void Moving_Unselected_Child_Item_From_Before_Selected_Item_To_After_Updates_State()
+            {
+                var data = CreateData();
+                var target = CreateTarget(data);
+                var indexesChangedRaised = 0;
+                var selectionChangedRaised = 0;
+                var selectedIndexRaised = 0;
+                var selectedItemRaised = 0;
+
+                target.Select(new IndexPath(1, 1));
+
+                target.IndexesChanged += (s, e) =>
+                {
+                    Assert.Equal(new(1), e.ParentIndex);
+                    Assert.Equal(0, e.StartIndex);
+                    Assert.Equal(2, e.EndIndex);
+                    Assert.Equal(-1, e.Delta);
+                    ++indexesChangedRaised;
+                };
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.SelectedIndex))
+                    {
+                        ++selectedIndexRaised;
+                    }
+
+                    if (e.PropertyName == nameof(target.SelectedItem))
+                    {
+                        ++selectedItemRaised;
+                    }
+                };
+
+                target.SelectionChanged += (s, e) =>
+                {
+                    ++selectionChangedRaised;
+                };
+
+                data[1].Children!.Move(0, 2);
+
+                Assert.Equal(1, target.Count);
+                Assert.Equal(new(1, 0), target.SelectedIndex);
+                Assert.Equal([new(1, 0)], target.SelectedIndexes);
+                Assert.Equal("Node 1-1", target.SelectedItem?.Caption);
+                Assert.Equal(["Node 1-1"], target.SelectedItems.Select(x => x?.Caption));
+                Assert.Equal(1, indexesChangedRaised);
+                Assert.Equal(0, selectionChangedRaised);
+                Assert.Equal(1, selectedIndexRaised);
+                Assert.Equal(0, selectedItemRaised);
+            }
+
+            [AvaloniaFact(Timeout = 10000)]
+            public void Moving_Unselected_Child_Item_From_After_Selected_Item_To_Before_Updates_State()
+            {
+                var data = CreateData();
+                var target = CreateTarget(data);
+                var indexesChangedRaised = 0;
+                var selectionChangedRaised = 0;
+                var selectedIndexRaised = 0;
+                var selectedItemRaised = 0;
+
+                target.Select(new IndexPath(1, 1));
+
+                target.IndexesChanged += (s, e) =>
+                {
+                    Assert.Equal(new(1), e.ParentIndex);
+                    Assert.Equal(0, e.StartIndex);
+                    Assert.Equal(2, e.EndIndex);
+                    Assert.Equal(1, e.Delta);
+                    ++indexesChangedRaised;
+                };
+
+                target.PropertyChanged += (s, e) =>
+                {
+                    if (e.PropertyName == nameof(target.SelectedIndex))
+                    {
+                        ++selectedIndexRaised;
+                    }
+
+                    if (e.PropertyName == nameof(target.SelectedItem))
+                    {
+                        ++selectedItemRaised;
+                    }
+                };
+
+                target.SelectionChanged += (s, e) =>
+                {
+                    ++selectionChangedRaised;
+                };
+
+                data[1].Children!.Move(2, 0);
+
+                Assert.Equal(1, target.Count);
+                Assert.Equal(new(1, 2), target.SelectedIndex);
+                Assert.Equal([new(1, 2)], target.SelectedIndexes);
+                Assert.Equal("Node 1-1", target.SelectedItem?.Caption);
+                Assert.Equal(["Node 1-1"], target.SelectedItems.Select(x => x?.Caption));
+                Assert.Equal(1, indexesChangedRaised);
+                Assert.Equal(0, selectionChangedRaised);
+                Assert.Equal(1, selectedIndexRaised);
+                Assert.Equal(0, selectedItemRaised);
+            }
+
+
+            [AvaloniaFact(Timeout = 10000)]
             public void Resetting_Root_Updates_State()
             {
                 var data = CreateData();


### PR DESCRIPTION
Previously, a `NotifyCollectionChangedAction.Move` would cause `TreeSelectionNode` to throw a `NotSupportedException`. This PR allows `TreeSelectionNode` to handle moves.

Note that if the moved item is currently selected, it will be unselected: it does not try to preserve a moved selection as that will require an API change in `TreeSelectionModelIndexesChangedEventArgs` to notify of multiple index ranges being changed.