### PR TITLE
Fix Horizontal Misalignment of Cells During Vertical Scrolling

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnarPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridColumnarPresenterBase.cs
@@ -23,6 +23,16 @@ namespace Avalonia.Controls.Primitives
             return new Size(Math.Min(availableSize.Width, column.MaxActualWidth), availableSize.Height);
         }
 
+        protected override (int index, double position) GetOrEstimateAnchorElementForViewport(
+            double viewportStart,
+            double viewportEnd,
+            int itemCount)
+        {
+            if (Columns?.GetColumnAt(viewportStart) is var (index, position) && index >= 0)
+                return (index, position);
+            return base.GetOrEstimateAnchorElementForViewport(viewportStart, viewportEnd, itemCount);
+        }
+
         protected sealed override bool NeedsFinalMeasurePass(int firstIndex, IReadOnlyList<Control?> elements)
         {
             var columns = Columns!;

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -397,6 +397,20 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
+        protected virtual (int index, double position) GetOrEstimateAnchorElementForViewport(
+            double viewportStart,
+            double viewportEnd,
+            int itemCount)
+        {
+            Debug.Assert(_realizedElements is not null);
+
+            return _realizedElements.GetOrEstimateAnchorElementForViewport(
+                viewportStart,
+                viewportEnd,
+                itemCount,
+                ref _lastEstimatedElementSizeU);
+        }
+
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
@@ -539,11 +553,7 @@ namespace Avalonia.Controls.Primitives
 
             // Get or estimate the anchor element from which to start realization.
             var itemCount = items.Count;
-            var (anchorIndex, anchorU) = _realizedElements.GetOrEstimateAnchorElementForViewport(
-                viewportStart,
-                viewportEnd,
-                itemCount,
-                ref _lastEstimatedElementSizeU);
+            var (anchorIndex, anchorU) = GetOrEstimateAnchorElementForViewport(viewportStart, viewportEnd, itemCount);
 
             // Check if the anchor element is not within the currently realized elements.
             var disjunct = anchorIndex < _realizedElements.FirstIndex ||

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
@@ -1,19 +1,15 @@
-﻿using Avalonia.Collections;
-using Avalonia.Controls.Models.TreeDataGrid;
-using Avalonia.Controls.Primitives;
-using Avalonia.Controls.Selection;
-using Avalonia.Layout;
-using Avalonia.LogicalTree;
-using Avalonia.Styling;
-using Avalonia.VisualTree;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using Avalonia.Controls.Embedding;
-using Avalonia.Headless;
+using Avalonia.Collections;
+using Avalonia.Controls.Models.TreeDataGrid;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Selection;
 using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using Xunit;
 using Enumerable = System.Linq.Enumerable;
 
@@ -379,6 +375,53 @@ namespace Avalonia.Controls.TreeDataGridTests
             Assert.Equal(60, columns[0].ActualWidth);
             Assert.Equal(20, columns[1].ActualWidth);
             Assert.Equal(20, columns[2].ActualWidth);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Should_Correctly_Align_Columns_When_Vertically_Scrolling_With_First_Column_Unrealized()
+        {
+            // Issue #298
+            static void AssertRealizedCells(TreeDataGrid target)
+            {
+                var rows = target.RowsPresenter!.GetVisualChildren().Cast<TreeDataGridRow>();
+
+                foreach (var row in rows)
+                {
+                    var cells = row.CellsPresenter!.GetRealizedElements()
+                        .Cast<TreeDataGridCell>()
+                        .OrderBy(x => x.ColumnIndex)
+                        .ToList();
+
+                    Assert.Equal(3, cells.Count);
+                    Assert.Equal(1, cells[0].ColumnIndex);
+                    Assert.Equal(100, cells[0].Bounds.Left);
+                    Assert.Equal(150, cells[1].Bounds.Left);
+                    Assert.Equal(200, cells[2].Bounds.Left);
+                }
+            }
+
+            var (target, items) = CreateTarget(columns:
+            [
+                new TextColumn<Model, int>("ID", x => x.Id, width: new GridLength(100, GridUnitType.Pixel)),
+                new TextColumn<Model, string?>("Title1", x => x.Title, width: new GridLength(50, GridUnitType.Pixel)),
+                new TextColumn<Model, string?>("Title2", x => x.Title, width: new GridLength(50, GridUnitType.Pixel)),
+                new TextColumn<Model, string?>("Title3", x => x.Title, width: new GridLength(50, GridUnitType.Pixel)),
+            ]);
+
+            // Scroll horizontally and check that the realized cells are positioned correctly.
+            target.Scroll!.Offset = new Vector(120, 0);
+            target.UpdateLayout();
+            AssertRealizedCells(target);
+
+            // Scroll down a row and check that the realized cells are positioned correctly.
+            target.Scroll!.Offset = new Vector(120, 10);
+            target.UpdateLayout();
+            AssertRealizedCells(target);
+
+            // Now scroll back vertically and check once more.
+            target.Scroll!.Offset = new Vector(120, 0);
+            target.UpdateLayout();
+            AssertRealizedCells(target);
         }
 
         public class RemoveItems


### PR DESCRIPTION
For columnar layouts, there should usually be be no need to estimate the x position of the column start in the viewport, as this information can be queried from `IColumns`. Make a new `GetOrEstimateAnchorElementForViewport` virtual method and override its behavior for columnar presenters.

Fixes #298 
