### PR TITLE
Fix horizontal scrollbar disappearing when rows removed

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -639,9 +639,8 @@ namespace Avalonia.Controls.Primitives
             {
                 if (!c.Bounds.Equals(default) && c.TransformToVisual(this) is Matrix transform)
                 {
-                    return new Rect(0, 0, c.Bounds.Width, c.Bounds.Height)
-                        .TransformToAABB(transform)
-                        .Intersect(new(0, 0, double.PositiveInfinity, double.PositiveInfinity));
+                    var r = new Rect(0, 0, c.Bounds.Width, c.Bounds.Height).TransformToAABB(transform);
+                    return Intersect(r, new(0, 0, double.PositiveInfinity, double.PositiveInfinity));
                 }
 
                 c = c?.GetVisualParent();

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRowsPresenter.cs
@@ -57,6 +57,17 @@ namespace Avalonia.Controls.Primitives
             ChildIndexChanged?.Invoke(this, new ChildIndexChangedEventArgs(element, ((TreeDataGridRow)element).RowIndex));
         }
 
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            var result = base.MeasureOverride(availableSize);
+
+            // If we have no rows, then get the width from the columns.
+            if (Columns is not null && (Items is null || Items.Count == 0))
+                result = result.WithWidth(Columns.GetEstimatedWidth(availableSize.Width));
+
+            return result;
+        }
+
         protected override Size ArrangeOverride(Size finalSize)
         {
             Columns?.CommitActualWidths();

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TestTemplates.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TestTemplates.cs
@@ -61,12 +61,20 @@ namespace Avalonia.Controls.TreeDataGridTests
                 {
                     Children =
                     {
-                        new TreeDataGridColumnHeadersPresenter
+                        new ScrollViewer
                         {
-                            Name = "PART_ColumnHeadersPresenter",
+                            Name = "PART_HeaderScrollViewer",
+                            Template = ScrollViewerTemplate(),
+                            Height = 0,
+                            HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden,
+                            VerticalScrollBarVisibility = ScrollBarVisibility.Disabled,
                             [DockPanel.DockProperty] = Dock.Top,
-                            [!TreeDataGridColumnHeadersPresenter.ElementFactoryProperty] = x[!TreeDataGrid.ElementFactoryProperty],
-                            [!TreeDataGridColumnHeadersPresenter.ItemsProperty] = x[!TreeDataGrid.ColumnsProperty],
+                            Content = new TreeDataGridColumnHeadersPresenter
+                            {
+                                Name = "PART_ColumnHeadersPresenter",
+                                [!TreeDataGridColumnHeadersPresenter.ElementFactoryProperty] = x[!TreeDataGrid.ElementFactoryProperty],
+                                [!TreeDataGridColumnHeadersPresenter.ItemsProperty] = x[!TreeDataGrid.ColumnsProperty],
+                            }.RegisterInNameScope(ns),
                         }.RegisterInNameScope(ns),
                         new ScrollViewer
                         {

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
@@ -560,6 +560,69 @@ namespace Avalonia.Controls.TreeDataGridTests
             }
         }
 
+        [AvaloniaFact(Timeout = 10000)]
+        public void Should_Show_Horizontal_ScrollBar()
+        {
+            var (target, items) = CreateTarget(columns:
+            [
+                new TextColumn<Model, int>("ID", x => x.Id, width: new GridLength(100, GridUnitType.Pixel)),
+                new TextColumn<Model, string?>("Title1", x => x.Title,  width: new GridLength(100, GridUnitType.Pixel)),
+            ]);
+            var scroll = Assert.IsType<ScrollViewer>(target.Scroll);
+            var headerScroll = Assert.IsType<ScrollViewer>(
+                target.GetVisualDescendants().Single(x => x.Name == "PART_HeaderScrollViewer"));
+
+            Assert.Equal(new(100, 100), scroll.Viewport);
+            Assert.Equal(new(200, 1000), scroll.Extent);
+            Assert.Equal(new(100, 0), headerScroll.Viewport);
+            Assert.Equal(new(200, 0), headerScroll.Extent);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Should_Show_Horizontal_ScrollBar_With_No_Initial_Rows()
+        {
+            var (target, items) = CreateTarget(columns:
+            [
+                new TextColumn<Model, int>("ID", x => x.Id, width: new GridLength(100, GridUnitType.Pixel)),
+                new TextColumn<Model, string?>("Title1", x => x.Title,  width: new GridLength(100, GridUnitType.Pixel)),
+            ], itemCount: 0);
+            var scroll = Assert.IsType<ScrollViewer>(target.Scroll);
+            var headerScroll = Assert.IsType<ScrollViewer>(
+                target.GetVisualDescendants().Single(x => x.Name == "PART_HeaderScrollViewer"));
+
+            Assert.Equal(new(100, 100), scroll.Viewport);
+            Assert.Equal(new(200, 100), scroll.Extent);
+            Assert.Equal(new(100, 0), headerScroll.Viewport);
+            Assert.Equal(new(200, 0), headerScroll.Extent);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Should_Preserve_Horizontal_ScrollBar_When_Rows_Removed()
+        {
+            var (target, items) = CreateTarget(columns:
+            [
+                new TextColumn<Model, int>("ID", x => x.Id, width: new GridLength(100, GridUnitType.Pixel)),
+                new TextColumn<Model, string?>("Title1", x => x.Title,  width: new GridLength(100, GridUnitType.Pixel)),
+            ]);
+            var scroll = Assert.IsType<ScrollViewer>(target.Scroll);
+            var headerScroll = Assert.IsType<ScrollViewer>(
+                target.GetVisualDescendants().Single(x => x.Name == "PART_HeaderScrollViewer"));
+
+            scroll.PropertyChanged += (s, e) => 
+            { 
+                if (e.Property == ScrollViewer.ExtentProperty)
+                {
+                }
+            };
+            items.Clear();
+            target.UpdateLayout();
+
+            Assert.Equal(new(100, 100), scroll.Viewport);
+            Assert.Equal(new(200, 100), scroll.Extent);
+            Assert.Equal(new(100, 0), headerScroll.Viewport);
+            Assert.Equal(new(200, 0), headerScroll.Extent);
+        }
+
         private static void AssertRowIndexes(TreeDataGrid target, int firstRowIndex, int rowCount)
         {
             var presenter = target.RowsPresenter;


### PR DESCRIPTION
Previously, if a horizontal scrollbar was needed to show all columns but there were no rows then no horizontal scrollbar was shown.

Fix this by getting the desired width for the `TreeDataGridRowsPresenter` from the columns if there are no rows.

Had to also update the test templates to include a column scroll viewer. Because the existing tests expect the column header to be of 0 height, needed to work around https://github.com/AvaloniaUI/Avalonia/issues/15075 in `TreeDataGridPresenterBase`.