### PR TITLE
Added `TreeDataGrid.CellValueChanged` event.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -74,7 +74,7 @@ namespace Avalonia.Controls.Primitives
             Model = null;
         }
 
-        protected void BeginEdit()
+        protected internal void BeginEdit()
         {
             if (!IsEditing)
             {
@@ -84,18 +84,19 @@ namespace Avalonia.Controls.Primitives
             }
         }
 
-        protected void CancelEdit()
+        protected internal void CancelEdit()
         {
             if (EndEditCore() && Model is IEditableObject editable)
                 editable.CancelEdit();
         }
 
-        protected void EndEdit()
+        protected internal void EndEdit()
         {
             if (EndEditCore() && Model is IEditableObject editable)
             {
                 editable.EndEdit();
                 UpdateValue();
+                RaiseCellValueChanged();
             }
         }
 
@@ -117,7 +118,7 @@ namespace Avalonia.Controls.Primitives
 
         protected void RaiseCellValueChanged()
         {
-            if (ColumnIndex != -1 && RowIndex != -1)
+            if (!IsEditing && ColumnIndex != -1 && RowIndex != -1)
                 _treeDataGrid?.RaiseCellValueChanged(this, ColumnIndex, RowIndex);
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCell.cs
@@ -115,6 +115,12 @@ namespace Avalonia.Controls.Primitives
         {
         }
 
+        protected void RaiseCellValueChanged()
+        {
+            if (ColumnIndex != -1 && RowIndex != -1)
+                _treeDataGrid?.RaiseCellValueChanged(this, ColumnIndex, RowIndex);
+        }
+
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
             _treeDataGrid = this.FindLogicalAncestorOfType<TreeDataGrid>();

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCheckBoxCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCheckBoxCell.cs
@@ -47,8 +47,12 @@ namespace Avalonia.Controls.Primitives
             get => _value;
             set
             {
-                if (SetAndRaise(ValueProperty, ref _value, value) && Model is CheckBoxCell cell)
-                    cell.Value = value;
+                if (SetAndRaise(ValueProperty, ref _value, value))
+                {
+                    if (Model is CheckBoxCell cell)
+                        cell.Value = value;
+                    RaiseCellValueChanged();
+                }
             }
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTemplateCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTemplateCell.cs
@@ -33,10 +33,14 @@ namespace Avalonia.Controls.Primitives
         private IDataTemplate? _editingTemplate;
         private ContentPresenter? _editingContentPresenter;
 
-        public object? Content 
-        { 
+        public object? Content
+        {
             get => _content;
-            private set => SetAndRaise(ContentProperty, ref _content, value);
+            private set
+            {
+                if (SetAndRaise(ContentProperty, ref _content, value))
+                    RaiseCellValueChanged();
+            }
         }
 
         public IDataTemplate? ContentTemplate 

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
@@ -55,8 +55,12 @@ namespace Avalonia.Controls.Primitives
             get => _value;
             set
             {
-                if (SetAndRaise(ValueProperty, ref _value, value) && Model is ITextCell cell && !_modelValueChanging)
-                    cell.Text = _value;
+                if (SetAndRaise(ValueProperty, ref _value, value) && Model is ITextCell cell)
+                {
+                    if (!_modelValueChanging)
+                        cell.Text = _value;
+                    RaiseCellValueChanged();
+                }
             }
         }
 

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -212,6 +212,7 @@ namespace Avalonia.Controls
 
         public event EventHandler<TreeDataGridCellEventArgs>? CellClearing;
         public event EventHandler<TreeDataGridCellEventArgs>? CellPrepared;
+        public event EventHandler<TreeDataGridCellEventArgs>? CellValueChanged;
         public event EventHandler<TreeDataGridRowEventArgs>? RowClearing;
         public event EventHandler<TreeDataGridRowEventArgs>? RowPrepared;
 
@@ -411,6 +412,17 @@ namespace Avalonia.Controls
                 _cellArgs ??= new TreeDataGridCellEventArgs();
                 _cellArgs.Update(cell, columnIndex, rowIndex);
                 CellPrepared(this, _cellArgs);
+                _cellArgs.Update(null, -1, -1);
+            }
+        }
+
+        internal void RaiseCellValueChanged(TreeDataGridCell cell, int columnIndex, int rowIndex)
+        {
+            if (CellValueChanged is not null)
+            {
+                _cellArgs ??= new TreeDataGridCellEventArgs();
+                _cellArgs.Update(cell, columnIndex, rowIndex);
+                CellValueChanged(this, _cellArgs);
                 _cellArgs.Update(null, -1, -1);
             }
         }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
@@ -289,6 +289,51 @@ namespace Avalonia.Controls.TreeDataGridTests
         }
 
         [AvaloniaFact(Timeout = 10000)]
+        public void Raises_CellValueChanged_When_Model_Value_Changed()
+        {
+            var (target, items) = CreateTarget();
+            var raised = 0;
+
+            target.CellValueChanged += (s, e) =>
+            {
+                Assert.Equal(1, e.ColumnIndex);
+                Assert.Equal(1, e.RowIndex);
+                ++raised;
+            };
+
+            items[1].Title = "Changed";
+
+            Assert.Equal(1, raised);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Does_Not_Raise_CellValueChanged_Events_On_Initial_Layout()
+        {
+            var (target, items) = CreateTarget(runLayout: false);
+            var raised = 0;
+
+            target.CellValueChanged += (s, e) => ++raised;
+
+            target.UpdateLayout();
+
+            Assert.Equal(0, raised);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Does_Not_Raise_CellValueChanged_Events_On_Scroll()
+        {
+            var (target, items) = CreateTarget();
+            var raised = 0;
+
+            target.CellValueChanged += (s, e) => ++raised;
+
+            target.Scroll!.Offset = new Vector(0, 10);
+            Layout(target);
+
+            Assert.Equal(0, raised);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
         public void Does_Not_Realize_Columns_Outside_Viewport()
         {
             var (target, items) = CreateTarget(columns: new IColumn<Model>[]
@@ -785,8 +830,14 @@ namespace Avalonia.Controls.TreeDataGridTests
 
         private class Model : NotifyingBase
         {
+            private string? _title;
+
             public int Id { get; set; }
-            public string? Title { get; set; }
+            public string? Title 
+            { 
+                get => _title;
+                set => RaiseAndSetIfChanged(ref _title, value);
+            }
         }
     }
 }

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
@@ -307,6 +307,32 @@ namespace Avalonia.Controls.TreeDataGridTests
         }
 
         [AvaloniaFact(Timeout = 10000)]
+        public void Raises_CellValueChanged_After_Cell_Edit()
+        {
+            var (target, items) = CreateTarget();
+            var raised = 0;
+
+            target.CellValueChanged += (s, e) =>
+            {
+                Assert.Equal(1, e.ColumnIndex);
+                Assert.Equal(1, e.RowIndex);
+                ++raised;
+            };
+
+            var cell = Assert.IsType<TreeDataGridTextCell>(target.TryGetRow(1)?.TryGetCell(1));
+            cell.BeginEdit();
+            cell.Value = "Changed";
+
+            Assert.Equal(0, raised);
+            Assert.Equal("Item 1", items[1].Title);
+
+            cell.EndEdit();
+
+            Assert.Equal("Changed", items[1].Title);
+            Assert.Equal(1, raised);
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
         public void Does_Not_Raise_CellValueChanged_Events_On_Initial_Layout()
         {
             var (target, items) = CreateTarget(runLayout: false);
@@ -768,7 +794,7 @@ namespace Avalonia.Controls.TreeDataGridTests
             else
             {
                 source.Columns.Add(new TextColumn<Model, int>("ID", x => x.Id));
-                source.Columns.Add(new TextColumn<Model, string?>("Title", x => x.Title));
+                source.Columns.Add(new TextColumn<Model, string?>("Title", x => x.Title, (o, v) => o.Title = v));
             }
 
             var target = new TreeDataGrid


### PR DESCRIPTION
This event will be raised when the cell value is changed between the `CellPrepared` and `CellClearing` events.

You can find a simple example of its usage to [this branch](https://github.com/AvaloniaUI/Avalonia.Controls.TreeDataGrid/tree/example%2Fcell-value-changed)