### PR TITLE
Fix text cell StringFormat not being displayed.

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridTextCell.cs
@@ -118,7 +118,7 @@ namespace Avalonia.Controls.Primitives
                 try
                 {
                     _modelValueChanging = true;
-                    Value = Model?.Value?.ToString();
+                    UpdateValue();
                 }
                 finally
                 {

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TreeDataGridTests_Flat.cs
@@ -495,6 +495,55 @@ namespace Avalonia.Controls.TreeDataGridTests
             AssertRealizedCells(target);
         }
 
+        [AvaloniaFact(Timeout = 10000)]
+        public void Should_Use_TextCell_StringFormat()
+        {
+            var (target, items) = CreateTarget(columns: new IColumn<Model>[]
+            {
+                new TextColumn<Model, string?>("Title", x => x.Title, options: new()
+                {
+                    StringFormat = "Hello {0}"
+                }),
+            });
+
+            var rows = target.RowsPresenter!
+                .GetVisualChildren()
+                .Cast<TreeDataGridRow>()
+                .ToList();
+
+            Assert.Equal(10, rows.Count);
+
+            for (var i = 0; i < rows.Count; i++)
+            {
+                var cell = Assert.IsType<TreeDataGridTextCell>(
+                    Assert.Single(rows[i].CellsPresenter!.GetVisualChildren().Cast<TreeDataGridCell>()));
+                Assert.Equal($"Hello Item {i}", cell.Value);
+            }
+        }
+
+        [AvaloniaFact(Timeout = 10000)]
+        public void Should_Use_TextCell_StringFormat_When_Model_Is_Updated()
+        {
+            var (target, items) = CreateTarget(columns: new IColumn<Model>[]
+            {
+                new TextColumn<Model, string?>("Title", x => x.Title, options: new()
+                {
+                    StringFormat = "Hello {0}"
+                }),
+            });
+
+            var rows = target.RowsPresenter!
+                .GetVisualChildren()
+                .Cast<TreeDataGridRow>()
+                .ToList();
+
+            Assert.Equal(10, rows.Count);
+            items[1].Title = "World";
+            var cell = Assert.IsType<TreeDataGridTextCell>(target.TryGetCell(0, 1));
+
+            Assert.Equal("Hello World", cell.Value);
+        }
+
         public class RemoveItems
         {
             [AvaloniaFact(Timeout = 10000)]


### PR DESCRIPTION
Fix text cell's `StringFormat` not being displayed when model value changes: we need to always use the `Text` property on `ITextCell` - not `Value` as `Value` does not have the string format applied.