### PR TITLE
Fix Layout Cycle bug when the user is using AutoColumns

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
@@ -135,6 +135,12 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             ActualWidth = width;
             _starWidthWasConstrained = false;
 
+            // MathUtilites.AreClose will return true for this condition.
+            // If the user has auto columns that are not yet realized, then the
+            // _autoWidth will remain NaN.
+            // This will lead to an endless layout cycle causing the whole UI
+            // to have degraded performance, until all columns have an actual value
+            // set for _autoWidth.
             if (double.IsNaN(oldWidth) && double.IsNaN(ActualWidth))
             {
                 return false;

--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ColumnBase`1.cs
@@ -134,6 +134,12 @@ namespace Avalonia.Controls.Models.TreeDataGrid
             var oldWidth = ActualWidth;
             ActualWidth = width;
             _starWidthWasConstrained = false;
+
+            if (double.IsNaN(oldWidth) && double.IsNaN(ActualWidth))
+            {
+                return false;
+            }
+            
             return !MathUtilities.AreClose(oldWidth, ActualWidth);
         }
 


### PR DESCRIPTION
This bug causes all kinds of symptoms:

Cells appearing in the wrong column,
total breakdown of ui performance,
totally broken horizontal scrolling.

What happens is this:

The user has all Auto sized columns or many Auto sized columns:

ColumnBase

```
bool IUpdateColumnLayout.CommitActualWidth()
        {
            var width = Width.GridUnitType switch
            {
                GridUnitType.Auto => _autoWidth,
                GridUnitType.Pixel => CoerceActualWidth(Width.Value),
                GridUnitType.Star => _starWidth,
                _ => throw new NotSupportedException(),
            };

            var oldWidth = ActualWidth;
            ActualWidth = width;
            _starWidthWasConstrained = false;
            
            return !MathUtilities.AreClose(oldWidth, ActualWidth);
        }
```
        
        The return value of this function decides if InvalidateMeasure will be called (except we are inside Measure already).
        
        However with AutoColumns ActualWidth can remain NaN for unrealised cells. When you pass NaN, NaN to AreClose
        it returns false.
        
        This means that when you have auto columns that are unrealised you will always InvalidateMeasure causing a layout cycle.
        
        
        The fix:
        
```
        if (double.IsNaN(oldWidth) && double.IsNaN(ActualWidth))
            {
                return false;
            }
```
        
        