### PR TITLE
Memory Leak fixes

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -413,6 +413,9 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnAttachedToVisualTree(e);
             _scrollViewer = this.FindAncestorOfType<ScrollViewer>();
+            
+            // Subscribing to this event adds a reference to 'this' in the layout manager.
+            // so this must be unsubscribed to avoid memory leaks.
             EffectiveViewportChanged += OnEffectiveViewportChanged;
             
             SubscribeToItemChanges();
@@ -422,6 +425,7 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnDetachedFromVisualTree(e);
             _scrollViewer = null;
+            
             EffectiveViewportChanged -= OnEffectiveViewportChanged;
 
             UnsubscribeFromItemChanges();

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -53,7 +53,6 @@ namespace Avalonia.Controls.Primitives
             _recycleElement = RecycleElement;
             _recycleElementOnItemRemoved = RecycleElementOnItemRemoved;
             _updateElementIndex = UpdateElementIndex;
-            EffectiveViewportChanged += OnEffectiveViewportChanged;
         }
 
         public TreeDataGridElementFactory? ElementFactory
@@ -415,12 +414,14 @@ namespace Avalonia.Controls.Primitives
         {
             base.OnAttachedToVisualTree(e);
             _scrollViewer = this.FindAncestorOfType<ScrollViewer>();
+            EffectiveViewportChanged += OnEffectiveViewportChanged;
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromVisualTree(e);
             _scrollViewer = null;
+            EffectiveViewportChanged -= OnEffectiveViewportChanged;
         }
 
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)


### PR DESCRIPTION
A few memory leaks can occur if your TreeDataGrid is removed from the visualtree but your viewmodel remains alive.

This happens for example when switching tabs in an application where the views are removed from the visual tree.

There are 2 causes:

1. Subscription to EffectiveViewPortChanged event, this causes a reference to be held by the layout manager.
2. Subscription to INCC events, for example the ColumnsList is owned by the users ViewModel, but events are subscribed by the Items property, and remain so.


The fix is to handle subscribing and unsubscribing in Attached/Detached to visual tree.