### PR TITLE
Support nullable TreeDataGridRow in drag-and-drop events for empty grids

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -607,7 +607,7 @@ namespace Avalonia.Controls
 
         [MemberNotNullWhen(true, nameof(_source))]
         private bool CalculateAutoDragDrop(
-            TreeDataGridRow targetRow,
+            TreeDataGridRow? targetRow,
             DragEventArgs e,
             [NotNullWhen(true)] out DragInfo? data,
             out TreeDataGridRowDropPosition position)
@@ -616,6 +616,7 @@ namespace Avalonia.Controls
                 e.Data.Get(DragInfo.DataFormat) is not DragInfo di ||
                 _source is null ||
                 _source.IsSorted ||
+                targetRow is null ||
                 di.Source != _source)
             {
                 data = null;
@@ -647,7 +648,6 @@ namespace Avalonia.Controls
             if (!TryGetRow(e.Source as Control, out var row))
             {
                 e.DragEffects = DragDropEffects.None;
-                return;
             }
 
             if (!CalculateAutoDragDrop(row, e, out _, out var adorner))
@@ -663,7 +663,10 @@ namespace Avalonia.Controls
                 adorner = ev.Position;
             }
 
-            ShowDragAdorner(row, adorner);
+            if (row != null)
+            {
+                ShowDragAdorner(row, adorner);
+            }
 
             if (Scroll is ScrollViewer scroller)
             {
@@ -687,8 +690,7 @@ namespace Avalonia.Controls
         {
             StopDrag();
 
-            if (!TryGetRow(e.Source as Control, out var row))
-                return;
+            TryGetRow(e.Source as Control, out var row);
 
             var autoDrop = CalculateAutoDragDrop(row, e, out var data, out var position);
             var route = BuildEventRoute(RowDropEvent);
@@ -707,6 +709,7 @@ namespace Avalonia.Controls
 
             if (autoDrop &&
                 _source is not null &&
+                row is not null &&
                 position != TreeDataGridRowDropPosition.None)
             {
                 var targetIndex = _source.Rows.RowIndexToModelIndex(row.RowIndex);

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGridRowDragEventArgs.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGridRowDragEventArgs.cs
@@ -24,7 +24,7 @@ namespace Avalonia.Controls
         /// <param name="routedEvent">The event being raised.</param>
         /// <param name="row">The row that is being dragged over.</param>
         /// <param name="inner">The inner drag event args.</param>
-        public TreeDataGridRowDragEventArgs(RoutedEvent routedEvent, TreeDataGridRow row, DragEventArgs inner)
+        public TreeDataGridRowDragEventArgs(RoutedEvent routedEvent, TreeDataGridRow? row, DragEventArgs inner)
             : base(routedEvent)
         {
             TargetRow = row;
@@ -39,7 +39,7 @@ namespace Avalonia.Controls
         /// <summary>
         /// Gets the row being dragged over.
         /// </summary>
-        public TreeDataGridRow TargetRow { get; }
+        public TreeDataGridRow? TargetRow { get; }
 
         /// <summary>
         /// Gets or sets a value indicating the how the data should be dropped into


### PR DESCRIPTION
This change enables support for custom event handlers in scenarios where the TreeDataGrid is empty, by permitting TreeDataGridRow to be null.