### PR TITLE
Try and maintain the column measure state if the source changes - Fixes horizontal scroll issue

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -90,6 +90,16 @@ namespace Avalonia.Controls.Primitives
         protected abstract Orientation Orientation { get; }
         protected Rect Viewport { get; private set; } = s_invalidViewport;
 
+        public void ScrollToHome()
+        {
+            _scrollViewer?.ScrollToHome();
+        }
+
+        public void ScrollToEnd()
+        {
+            _scrollViewer?.ScrollToEnd();
+        }
+
         public Control? BringIntoView(int index, Rect? rect = null)
         {
             var items = Items;


### PR DESCRIPTION
If they user changes the source… we dont reset the scroll offsets, we load the new data, but loose the measured column widths.

This leads to cells no longer being correctly arranged for the new data.

This PR tries to maintain the measure information if it determines the columns match the previous source, if not it resets the scrollviewer to the top left.

This can be common where the user is displaying the same data but reconfigures the source, perhaps for groupings, and the user is horizontally scrolled.

