### PR TITLE
Correctly handle recycling following changes to Items when the TDG is not attached to the VisualTree

### DIFF
--- a/Avalonia.Controls.TreeDataGrid.sln
+++ b/Avalonia.Controls.TreeDataGrid.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{AE911386
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "_build", "nukebuild\_build.csproj", "{D45C7B46-A12C-4412-8397-B51B75A09999}"
 EndProject
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Props", "Props", "{0F5B5686-C914-416E-ABA3-ED41A653626C}"
 	ProjectSection(SolutionItems) = preProject
 		build\SharedVersion.props = build\SharedVersion.props
@@ -45,9 +46,7 @@ Global
 		{9A36E37E-2C03-4B5A-B7EE-A91DC95C3E4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9A36E37E-2C03-4B5A-B7EE-A91DC95C3E4A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D45C7B46-A12C-4412-8397-B51B75A09999}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D45C7B46-A12C-4412-8397-B51B75A09999}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D45C7B46-A12C-4412-8397-B51B75A09999}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D45C7B46-A12C-4412-8397-B51B75A09999}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Avalonia.Controls.TreeDataGrid.sln
+++ b/Avalonia.Controls.TreeDataGrid.sln
@@ -20,7 +20,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{AE911386
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "_build", "nukebuild\_build.csproj", "{D45C7B46-A12C-4412-8397-B51B75A09999}"
 EndProject
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Props", "Props", "{0F5B5686-C914-416E-ABA3-ED41A653626C}"
 	ProjectSection(SolutionItems) = preProject
 		build\SharedVersion.props = build\SharedVersion.props

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -429,6 +429,7 @@ namespace Avalonia.Controls.Primitives
             EffectiveViewportChanged -= OnEffectiveViewportChanged;
 
             UnsubscribeFromItemChanges();
+            RecycleAllElements();
         }
 
         protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)


### PR DESCRIPTION
If the user places the TDG inside a tab control and does the following:

1. add 5 items.
2. switch tabs to show and realize the 5 elements.
3. switch tabs to detach from the visual tree.
4. add 5 items (in non sequential order… inserts etc)
5. switch tabs back.

the user will see many rows that are duplicated… i.e. the recycling mechanism messed up and assigned the same model to multiple rows.

This PR fixes the issue by recycling all elements when a TdgPresenter is detached from the VisualTree.

(the same logic is already implemented from detaching from the logical tree, and in recent memory leak fixes we unsubscribe from item changes during the detached phase, meaning we now need to handle this on visual tree detach also)