### PR TITLE
CellsPresenter and use the RowsPresenter viewport instead of estimating

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridCellsPresenter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Xml.Linq;
 using Avalonia.Controls.Models.TreeDataGrid;
 using Avalonia.Controls.Selection;
@@ -61,6 +62,13 @@ namespace Avalonia.Controls.Primitives
                 if (element is TreeDataGridCell { RowIndex: >= 0, ColumnIndex: >= 0 } cell)
                     cell.UpdateRowIndex(index);
             }
+        }
+
+        protected override Rect? GetParentPresenterViewPort()
+        {
+            var parentRowPresenter = this.GetVisualAncestors().OfType<TreeDataGridRowsPresenter>().FirstOrDefault();
+
+            return parentRowPresenter?.Viewport;
         }
 
         protected override Size MeasureOverride(Size availableSize)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -88,7 +88,8 @@ namespace Avalonia.Controls.Primitives
         internal IReadOnlyList<Control?> RealizedElements => _realizedElements?.Elements ?? Array.Empty<Control>();
 
         protected abstract Orientation Orientation { get; }
-        protected Rect Viewport { get; private set; } = s_invalidViewport;
+        
+        internal Rect Viewport { get; private set; } = s_invalidViewport;
 
         public Control? BringIntoView(int index, Rect? rect = null)
         {
@@ -652,8 +653,18 @@ namespace Avalonia.Controls.Primitives
             return _lastEstimatedElementSizeU;
         }
 
+        protected virtual Rect? GetParentPresenterViewPort()
+        {
+            return null;
+        }
+
         private Rect EstimateViewport(Size availableSize)
         {
+            if (GetParentPresenterViewPort() is { } parentViewport && parentViewport != s_invalidViewport)
+            {
+                return parentViewport;
+            }
+            
             var c = this.GetVisualParent();
 
             if (c is null)

--- a/tests/Avalonia.Controls.TreeDataGrid.Tests/TestTemplates.cs
+++ b/tests/Avalonia.Controls.TreeDataGrid.Tests/TestTemplates.cs
@@ -54,7 +54,7 @@ namespace Avalonia.Controls.TreeDataGridTests
             Setters = { new Setter(TemplatedControl.TemplateProperty, ScrollViewerTemplate()) }
         };
 
-        public static IControlTemplate TreeDataGridTemplate()
+        public static IControlTemplate TreeDataGridTemplate(double headerPresenterSize = 0)
         {
             return new FuncControlTemplate<TreeDataGrid>((x, ns) =>
                 new DockPanel
@@ -65,7 +65,7 @@ namespace Avalonia.Controls.TreeDataGridTests
                         {
                             Name = "PART_HeaderScrollViewer",
                             Template = ScrollViewerTemplate(),
-                            Height = 0,
+                            Height = headerPresenterSize,
                             HorizontalScrollBarVisibility = ScrollBarVisibility.Hidden,
                             VerticalScrollBarVisibility = ScrollBarVisibility.Disabled,
                             [DockPanel.DockProperty] = Dock.Top,


### PR DESCRIPTION
In some circumstances the CellsPresenter has to estimate the viewport… the problem is that it doesnt estimate the horizontal scroll offset, causing the all cells and columns to be realized.

In this scenario its actually more efficient and easier to get the viewport from the parent RowsPresenter.

Added a unit test to setup the scenario and prove the fix.