### PR TITLE
Fix dynamic resource propagation into TDG headers and Cells (wire up the logical tree)

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -636,6 +636,7 @@ namespace Avalonia.Controls.Primitives
             if (e.GetVisualParent() is null)
             {
                 ((ISetLogicalParent)e).SetParent(this);
+                LogicalChildren.Add(e);
                 VisualChildren.Add(e);
             }
             return e;

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridPresenterBase.cs
@@ -730,6 +730,21 @@ namespace Avalonia.Controls.Primitives
                     }
                 }
             }
+            
+            var logicalChildren = LogicalChildren;
+            
+            if (logicalChildren.Count > count)
+            {
+                for (var i = logicalChildren.Count - 1; i >= 0; --i)
+                {
+                    var child = logicalChildren[i];
+
+                    if (child is Visual { IsVisible: false })
+                    {
+                        logicalChildren.RemoveAt(i);
+                    }
+                }
+            }
         }
 
         private void OnItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Primitives/TreeDataGridRow.cs
@@ -138,6 +138,11 @@ namespace Avalonia.Controls.Primitives
             base.OnApplyTemplate(e);
             CellsPresenter = e.NameScope.Find<TreeDataGridCellsPresenter>("PART_CellsPresenter");
 
+            if (CellsPresenter is { })
+            {
+                LogicalChildren.Add(CellsPresenter);
+            }
+            
             if (RowIndex >= 0)
                 CellsPresenter?.Realize(RowIndex);
         }

--- a/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/TreeDataGrid.cs
@@ -321,8 +321,16 @@ namespace Avalonia.Controls
             }
 
             base.OnApplyTemplate(e);
-            ColumnHeadersPresenter = e.NameScope.Find<TreeDataGridColumnHeadersPresenter>("PART_ColumnHeadersPresenter");
+            ColumnHeadersPresenter =
+                e.NameScope.Find<TreeDataGridColumnHeadersPresenter>("PART_ColumnHeadersPresenter");
             RowsPresenter = e.NameScope.Find<TreeDataGridRowsPresenter>("PART_RowsPresenter");
+
+            if (ColumnHeadersPresenter is { }) 
+                LogicalChildren.Add(ColumnHeadersPresenter);
+
+            if(RowsPresenter is { })
+                LogicalChildren.Add(RowsPresenter);
+            
             Scroll = e.NameScope.Find<ScrollViewer>("PART_ScrollViewer");
             _headerScroll = e.NameScope.Find<ScrollViewer>("PART_HeaderScrollViewer");
 


### PR DESCRIPTION
As the presenter realises items it currently adds them to visual children, but it does not add them to the logical children.

Because of this dynamic resource changes (which are only propagated to logical children) do not reach the column headers or cells.

This PR fixes it by adding to the logical children when an item is first attached.

```
private Control GetRecycledOrCreateElement(IReadOnlyList<TItem> items, int index)
{
    var item = items[index];
    var e = GetElementFromFactory(item, index);
    e.IsVisible = true;
    RealizeElement(e, item, index);
    if (e.GetVisualParent() is null)
    {
        ((ISetLogicalParent)e).SetParent(this);
        LogicalChildren.Add(e);    // this fixes it!
        VisualChildren.Add(e);
```


Iv also added an optional change which adds the presenters to the logical children so that column headers, rows and cells can be inspected in dev tools.

I dont remember the way to make it skip out the presenters themselves.

