### PR TITLE
fix(ITextSearchableColumn): make SelectValue not internal

### DIFF
--- a/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ISearchableTextColumn.cs
+++ b/src/Avalonia.Controls.TreeDataGrid/Models/TreeDataGrid/ISearchableTextColumn.cs
@@ -2,7 +2,7 @@
 {
     public interface ITextSearchableColumn<TModel>
     {
-        public bool IsTextSearchEnabled { get; }
-        internal string? SelectValue(TModel model);
+        bool IsTextSearchEnabled { get; }
+        string? SelectValue(TModel model);
     }
 }


### PR DESCRIPTION
Attempting to make a custom column with the ITextSearchableColumn inteface is not possible due to SelectValue being internal.

![image](https://github.com/user-attachments/assets/23406e20-376a-4c17-af51-952ea97e40b2)
